### PR TITLE
[FEAT] 투표 생성 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     // Global
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.material.icons.extended)
+    implementation(libs.kotlinx.immutable.collections)
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.mockk.agent)
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -40,7 +40,7 @@ fun ConsensusNavGraph() {
         }
 
         composable<Route.CreatePollScreen> {
-            CreatePollScreen()
+            CreatePollScreen(navController = navController)
         }
 
         composable<Route.VoteScreen>(

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -129,13 +129,11 @@ fun CreatePollScreen(
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    if (options.value.isNotEmpty()) {
-                        for (option in options.value) {
-                            OptionChip(
-                                option = option,
-                                onDelete = { viewModel.removeOption(option) }
-                            )
-                        }
+                    for (option in options.value) {
+                        OptionChip(
+                            option = option,
+                            onDelete = { viewModel.removeOption(option) }
+                        )
                     }
                     Button(
                         enabled = isNewOptionButtonEnabled,

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -145,7 +145,7 @@ fun CreatePollScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Add,
-                            contentDescription = null
+                            contentDescription = "Add Option"
                         )
                     }
                 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -54,9 +54,7 @@ fun CreatePollScreen(
     val handleSubmit: () -> Unit = { viewModel.submit() }
     val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
     val handleDialogConfirm: () -> Unit = {
-        if (newOption.value.isNotBlank() && !options.value.contains(newOption.value)) {
-            viewModel.appendOption(newOption.value)
-        }
+        viewModel.appendOption(newOption.value)
         viewModel.setDialogState(false)
         viewModel.setNewOption("")
     }
@@ -66,10 +64,10 @@ fun CreatePollScreen(
     }
 
     val isSubmitButtonEnabled = title.value.isNotEmpty()
-            && options.value.size >= 2
-            && options.value.size <= 3
+            && options.value.size >= MIN_OPTIONS
+            && options.value.size <= MAX_OPTIONS
             && uiState.value != UiState.Loading
-    val isNewOptionButtonEnabled = options.value.size < 3
+    val isNewOptionButtonEnabled = options.value.size < MAX_OPTIONS
 
     Scaffold(
         topBar = { CreatePollScreenTopBar(onBackClicked = handleBackClick) },

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -56,7 +56,9 @@ fun CreatePollScreen(
     val handleSubmit: () -> Unit = { viewModel.submit() }
     val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
     val handleDialogConfirm: () -> Unit = {
-        viewModel.appendOption(newOption.value)
+        if (newOption.value.isNotBlank() && !options.value.contains(newOption.value)) {
+            viewModel.appendOption(newOption.value)
+        }
         viewModel.setDialogState(false)
         viewModel.setNewOption("")
     }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -1,17 +1,178 @@
 package com.imeanttobe.consensusapp.ui.create_poll
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.HowToVote
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.ui.create_poll.components.AddOptionDialog
+import com.imeanttobe.consensusapp.ui.create_poll.components.CreatePollScreenTopBar
+import com.imeanttobe.consensusapp.ui.create_poll.components.InputItemDescription
+import com.imeanttobe.consensusapp.ui.create_poll.components.OptionChip
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun CreatePollScreen() {
-    Scaffold { innerPadding ->
-        Text(
-            text = "Create Poll Screen",
-            modifier = Modifier.padding(innerPadding),
+fun CreatePollScreen(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    viewModel: CreatePollViewModel = hiltViewModel()
+) {
+    val title = viewModel.title.collectAsStateWithLifecycle()
+    val numParticipants = viewModel.numParticipants.collectAsStateWithLifecycle()
+    val options = viewModel.options.collectAsStateWithLifecycle()
+    val newOption = viewModel.newOption.collectAsStateWithLifecycle()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
+
+    val handleBackClick: () -> Unit = { navController.popBackStack() }
+    val handleSliderChange: (Float) -> Unit = { sliderValue -> viewModel.setNumParticipants(sliderValue.toInt()) }
+    val handleSubmit: () -> Unit = { viewModel.submit() }
+    val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
+    val handleDialogConfirm: () -> Unit = {
+        viewModel.appendOption(newOption.value)
+        viewModel.setDialogState(false)
+        viewModel.setNewOption("")
+    }
+    val handleDialogDismiss: () -> Unit = {
+        viewModel.setDialogState(false)
+        viewModel.setNewOption("")
+    }
+
+    val isSubmitButtonEnabled = title.value.isNotEmpty()
+            && options.value.size >= 2
+            && options.value.size <= 3
+            && uiState.value != UiState.Loading
+    val isNewOptionButtonEnabled = options.value.size < 3
+
+    Scaffold(
+        topBar = { CreatePollScreenTopBar(onBackClicked = handleBackClick) },
+        modifier = modifier
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                // Title
+                InputItemDescription(
+                    title = "투표 제목",
+                    icon = Icons.Outlined.Edit,
+                    description = "투표의 제목을 입력해주세요.",
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                OutlinedTextField(
+                    value = title.value,
+                    onValueChange = viewModel::setTitle,
+                    label = { Text(text = "투표 제목") },
+                    singleLine = true,
+                    maxLines = 1,
+                    placeholder = { Text(text = "2025년 반장 선거")},
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)
+                )
+
+                // Participants
+                InputItemDescription(
+                    title = "참여 인원",
+                    icon = Icons.Outlined.Person,
+                    description = "참여 인원을 정해주세요. 최소 3명, 최대 10명까지 가능해요.",
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Slider(
+                    value = numParticipants.value.toFloat(),
+                    onValueChange = handleSliderChange,
+                    valueRange = MIN_PARTICIPANTS.toFloat()..MAX_PARTICIPANTS.toFloat(),
+                    steps = MAX_PARTICIPANTS - MIN_PARTICIPANTS - 1,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth().padding(8.dp).padding(bottom = 32.dp)
+                ) {
+                    for (i in MIN_PARTICIPANTS..MAX_PARTICIPANTS) {
+                        Text(text = i.toString(), color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+
+                // Options
+                InputItemDescription(
+                    title = "후보",
+                    icon = Icons.Outlined.HowToVote,
+                    description = "후보를 입력해주세요. 최소 2개, 최대 3개까지 가능해요.",
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (options.value.isNotEmpty()) {
+                        for (option in options.value) {
+                            OptionChip(
+                                option = option,
+                                onDelete = { viewModel.removeOption(option) }
+                            )
+                        }
+                    }
+                    Button(
+                        enabled = isNewOptionButtonEnabled,
+                        onClick = handleOpenDialog
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Add,
+                            contentDescription = null
+                        )
+                    }
+                }
+            }
+
+            // Submit button
+            Button(
+                onClick = handleSubmit,
+                enabled = isSubmitButtonEnabled,
+                contentPadding = ButtonDefaults.MediumContentPadding,
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
+            ) {
+                if (uiState.value is UiState.Loading) {
+                    CircularWavyProgressIndicator()
+                } else {
+                    Text(text = "투표 개최하기")
+                }
+            }
+        }
+    }
+
+    if (dialogState.value) {
+        AddOptionDialog(
+            newOption = newOption.value,
+            onNewOptionChange = viewModel::setNewOption,
+            onConfirm = handleDialogConfirm,
+            onDismiss = handleDialogDismiss
         )
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -58,7 +58,11 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
 
     fun removeOption(index: Int) {
         _options.update { currentList ->
-            currentList.removeAt(index)
+            if (index in currentList.indices) {
+                currentList.removeAt(index)
+            } else {
+                currentList
+            }
         }
     }
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -1,0 +1,74 @@
+package com.imeanttobe.consensusapp.ui.create_poll
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.imeanttobe.consensusapp.core.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+const val MAX_PARTICIPANTS = 10;
+const val MIN_PARTICIPANTS = 3;
+
+@HiltViewModel
+class CreatePollViewModel @Inject constructor() : ViewModel() {
+    private val _title = MutableStateFlow<String>("")
+    val title: StateFlow<String> = _title
+
+    private val _options = MutableStateFlow<PersistentList<String>>(persistentListOf())
+    val options: StateFlow<PersistentList<String>> = _options
+
+    private val _newOption = MutableStateFlow<String>("")
+    val newOption: StateFlow<String> = _newOption
+
+    private val _numParticipants = MutableStateFlow<Int>(3)
+    val numParticipants: StateFlow<Int> = _numParticipants
+
+    private val _uiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
+    val uiState: StateFlow<UiState<Unit>> = _uiState
+
+    private val _dialogState = MutableStateFlow<Boolean>(false)
+    val dialogState: StateFlow<Boolean> = _dialogState
+
+    fun setDialogState(state: Boolean) {
+        _dialogState.value = state
+    }
+
+    fun setNewOption(newOption: String) {
+        _newOption.value = newOption
+    }
+
+    fun setTitle(title: String) {
+        _title.value = title
+    }
+
+    fun setNumParticipants(numParticipants: Int) {
+        _numParticipants.value = numParticipants
+    }
+
+    fun appendOption(option: String) {
+        _options.update { currentList ->
+            currentList.add(option)
+        }
+    }
+
+    fun removeOption(index: Int) {
+        _options.update { currentList ->
+            currentList.removeAt(index)
+        }
+    }
+
+    fun removeOption(option: String) {
+        _options.update { currentList ->
+            currentList.remove(option)
+        }
+    }
+
+    fun submit() {
+
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -12,6 +12,8 @@ import javax.inject.Inject
 
 const val MAX_PARTICIPANTS = 10
 const val MIN_PARTICIPANTS = 3
+const val MAX_OPTIONS = 3
+const val MIN_OPTIONS = 2
 
 @HiltViewModel
 class CreatePollViewModel @Inject constructor() : ViewModel() {
@@ -50,8 +52,12 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
     }
 
     fun appendOption(option: String) {
+        if (option.isBlank()) {
+            return
+        }
+
         _options.update { currentList ->
-            if (currentList.size < 3 && !currentList.contains(option)) {
+            if (currentList.size < MAX_OPTIONS && !currentList.contains(option)) {
                 currentList.add(option)
             } else {
                 currentList

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
-const val MAX_PARTICIPANTS = 10;
-const val MIN_PARTICIPANTS = 3;
+const val MAX_PARTICIPANTS = 10
+const val MIN_PARTICIPANTS = 3
 
 @HiltViewModel
 class CreatePollViewModel @Inject constructor() : ViewModel() {
@@ -25,7 +25,7 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
     private val _newOption = MutableStateFlow<String>("")
     val newOption: StateFlow<String> = _newOption
 
-    private val _numParticipants = MutableStateFlow<Int>(3)
+    private val _numParticipants = MutableStateFlow<Int>(MIN_PARTICIPANTS)
     val numParticipants: StateFlow<Int> = _numParticipants
 
     private val _uiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
@@ -47,7 +47,7 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
     }
 
     fun setNumParticipants(numParticipants: Int) {
-        _numParticipants.value = numParticipants
+        _numParticipants.value = numParticipants.coerceIn(MIN_PARTICIPANTS, MAX_PARTICIPANTS)
     }
 
     fun appendOption(option: String) {
@@ -73,6 +73,6 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
     }
 
     fun submit() {
-
+        // TODO: Submit poll to server
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -52,7 +52,11 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
 
     fun appendOption(option: String) {
         _options.update { currentList ->
-            currentList.add(option)
+            if (currentList.size < 3 && !currentList.contains(option)) {
+                currentList.add(option)
+            } else {
+                currentList
+            }
         }
     }
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -1,6 +1,5 @@
 package com.imeanttobe.consensusapp.ui.create_poll
 
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.imeanttobe.consensusapp.core.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
@@ -18,6 +18,8 @@ fun AddOptionDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
+    val isConfirmButtonEnabled = newOption.isNotEmpty()
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(text = "새 후보 추가") },
@@ -41,7 +43,10 @@ fun AddOptionDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(
+                enabled = isConfirmButtonEnabled,
+                onClick = onConfirm
+            ) {
                 Text(text = "추가")
             }
         },

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
@@ -1,0 +1,54 @@
+package com.imeanttobe.consensusapp.ui.create_poll.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AddOptionDialog(
+    newOption: String,
+    onNewOptionChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = "새 후보 추가") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "새로 추가할 후보를 입력해주세요."
+                )
+                OutlinedTextField(
+                    value = newOption,
+                    onValueChange = onNewOptionChange,
+                    label = { Text(text = "후보") },
+                    singleLine = true,
+                    maxLines = 1,
+                    placeholder = { Text(text = "홍길동") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = "추가")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = "취소")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
@@ -46,7 +46,7 @@ fun AddOptionDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(onClick = onDismiss) {
                 Text(text = "취소")
             }
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/CreatePollScreenTopBar.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/CreatePollScreenTopBar.kt
@@ -1,0 +1,25 @@
+package com.imeanttobe.consensusapp.ui.create_poll.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreatePollScreenTopBar(
+    onBackClicked: () -> Unit
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = "투표 생성") },
+        navigationIcon = {
+            IconButton(onClick = onBackClicked) {
+                Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/CreatePollScreenTopBar.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/CreatePollScreenTopBar.kt
@@ -18,7 +18,10 @@ fun CreatePollScreenTopBar(
         title = { Text(text = "투표 생성") },
         navigationIcon = {
             IconButton(onClick = onBackClicked) {
-                Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = "Create Poll"
+                )
             }
         },
     )

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/InputItemDescription.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/InputItemDescription.kt
@@ -34,7 +34,7 @@ fun InputItemDescription(
             Icon(
                 imageVector = icon,
                 tint = MaterialTheme.colorScheme.primary,
-                contentDescription = null
+                contentDescription = "Input Icon"
             )
             Text(
                 text = title,

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/InputItemDescription.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/InputItemDescription.kt
@@ -1,0 +1,62 @@
+package com.imeanttobe.consensusapp.ui.create_poll.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun InputItemDescription(
+    title: String,
+    icon: ImageVector,
+    description: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        // Title
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                tint = MaterialTheme.colorScheme.primary,
+                contentDescription = null
+            )
+            Text(
+                text = title,
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        // Description
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun InputItemDescriptionPreview() {
+    InputItemDescription(
+        title = "투표 제목",
+        icon = Icons.Outlined.Add,
+        description = "투표의 제목을 입력해주세요."
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
@@ -23,7 +23,7 @@ fun OptionChip(
         trailingIcon = {
             Icon(
                 imageVector = Icons.Outlined.Close,
-                contentDescription = null,
+                contentDescription = "Delete Option",
                 modifier = Modifier.size(InputChipDefaults.AvatarSize)
             )
         },

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
@@ -23,7 +23,7 @@ fun OptionChip(
         trailingIcon = {
             Icon(
                 imageVector = Icons.Outlined.Close,
-                contentDescription = "Localized description",
+                contentDescription = null,
                 modifier = Modifier.size(InputChipDefaults.AvatarSize)
             )
         },

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/OptionChip.kt
@@ -1,0 +1,40 @@
+package com.imeanttobe.consensusapp.ui.create_poll.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun OptionChip(
+    option: String,
+    onDelete: () -> Unit
+) {
+    InputChip(
+        onClick = onDelete,
+        label = { Text(text = option) },
+        selected = true,
+        trailingIcon = {
+            Icon(
+                imageVector = Icons.Outlined.Close,
+                contentDescription = "Localized description",
+                modifier = Modifier.size(InputChipDefaults.AvatarSize)
+            )
+        },
+    )
+}
+
+@Preview
+@Composable
+fun OptionChipPreview() {
+    OptionChip(
+        option = "선택지 1",
+        onDelete = {}
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ datastore = "1.2.0"
 serialization = "1.9.0"
 mockk = "1.14.6"
 icon = "1.7.8"
+immutableCollections = "0.4.0"
 
 [libraries]
 # Default
@@ -61,6 +62,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
 material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "icon" }
+kotlinx-immutable-collections = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "immutableCollections" }
 
 [plugins]
 # Default


### PR DESCRIPTION
# 🚩 연관 이슈

closed #19 

# 📝 작업 내용
효율적인 리스트 관찰을 위해 Kotlin의 Immutable Collections 라이브러리를 도입하고, 투표 생성 화면과 뷰 모델 로직을 구현했어요.

## Kotlin의 Immutable Collections 도입 및 리스트 추적 성능 개선
기록하면 좋을 부분은 Compose가 리스트 관측을 더 효율적으로 할 수 있도록 개선한 부분이에요.

```kotlin
val items = MutableStateOf<List<Int>>(listOf(1, 2, 3))

val appendList: (Int) -> Unit = { newItem ->
    items.update { currentList ->
        currentList + newItem
    }
}
```
Android에서 상태 추적에 사용되는 타입인 `MutableStateFlow`는 관측 대상이 완전히 대체되어야(replaced) 상태가 변경된 것으로 파악해요. 그러나 리스트의 경우, 리스트에 원소를 1개, 2개 추가한다고 해서 리스트 자체가 대체되는 건 아니에요. 따라서, 변경 가능한 `MutableList`가 아니라 `List`로 선언하고, 그 리스트에 추가하고자 하는 원소를 포함한 리스트를 완전히 새로 생성해서 대체해주어야 해요. 하지만 이런 접근은 비용이 상당히 높습니다.

```kotlin
val items = MutableStateOf<PersistentList<Int>>(listOf(1, 2, 3))

val appendList: (Int) -> Unit = { newItem ->
    items.update { currentList ->
        currentList.append(newItem)
    }
}
```
Kotlin의 Immutable Collections는 완전히 이 목적을 위해 만들어졌다고 들었어요. 내부적으로 해시 테이블과 유사한 자료형을 사용하기 때문에, 추가 및 삭제에 큰 비용이 들지 않는다고 하네요. 훨씬 정확한 원리는 나중에 더 살펴봐야 할 것 같지만 일단은 이 정도로 기록 끝.

## 세부 구현 내용
- [x] Kotlin의 Immutable Collections 라이브러리 도입
- [x] 투표 생성 화면에 필요한 서브 컴포저블 구현 
- [x] 투표 생성 화면 구현
- [x] 투표 생성 화면의 뷰 모델 구현

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 투표 생성 화면을 MVVM 상태 기반으로 전면 재구성: 제목 입력, 후보 추가/삭제, 참가자 수 조정, 제출 흐름 및 로딩 표시 포함
  * 새 후보 추가 대화상자 추가(입력 유효성, 확인/취소 동작)
  * 상단 바, 후보 칩, 입력 설명 등 재사용 가능한 UI 컴포넌트 추가
  * 네비게이션 연동 및 제출 활성화 조건 적용

* **Chores**
  * 불변 컬렉션 라이브러리 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->