### PR TITLE
[FEAT] Retrofit2 도입 및 HTTP 클라이언트 구성

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Prepare local properties
+      - name: Prepare local properties
+        run: echo "${{ secrets.LOCAL_PROPERTIES }}" > local.properties
+
       # Specify changes
       - name: Check for changes
         uses: dorny/paths-filter@v3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,12 +58,12 @@ android {
         val isDevModeEnabled = parseBoolean(localProperties.getProperty("config.isDevModeEnabled"), false)
         val isHttpLoggingEnabled = parseBoolean(localProperties.getProperty("config.isHttpLoggingEnabled"), false)
         val apiBaseUrl = localProperties.getProperty("api.baseUrl")
+            ?: throw GradleException("API_BASE_URL is not set in local.properties")
 
         // Set the buildConfigField
         buildConfigField("Boolean", "IS_DEV_MODE_ENABLED", isDevModeEnabled.toString())
         buildConfigField("Boolean", "IS_HTTP_LOGGING_ENABLED", isHttpLoggingEnabled.toString())
         buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
-            ?: throw GradleException("API_BASE_URL is not set in local.properties")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,9 +56,11 @@ android {
 
         // Set the values from local.properties
         val isDevModeEnabled = parseBoolean(localProperties.getProperty("config.isDevModeEnabled"), false)
+        val apiBaseUrl = localProperties.getProperty("api.baseUrl")
 
         // Set the buildConfigField
         buildConfigField("Boolean", "IS_DEV_MODE_ENABLED", isDevModeEnabled.toString())
+        buildConfigField("String", "API_BASE_URL", apiBaseUrl)
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,7 @@ android {
 
         // Set the buildConfigField
         buildConfigField("Boolean", "IS_DEV_MODE_ENABLED", isDevModeEnabled.toString())
-        buildConfigField("String", "API_BASE_URL", apiBaseUrl)
+        buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,17 +130,21 @@ dependencies {
     implementation(libs.dagger.hilt.android)
     androidTestImplementation(libs.dagger.hilt.android.testing)
 
+    // Proto Datastore
+    implementation(libs.datastore.core)
+    implementation(libs.datastore.preferences)
+    implementation(libs.protobuf.kotlin.lite)
+
+    // Network
+    implementation(libs.squareup.retrofit2)
+    implementation(libs.squareup.retrofit2.converter.gson)
+
     // Global
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.material.icons.extended)
     implementation(libs.kotlinx.immutable.collections)
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.mockk.agent)
-
-    // Proto Datastore
-    implementation(libs.datastore.core)
-    implementation(libs.datastore.preferences)
-    implementation(libs.protobuf.kotlin.lite)
 
     // Default
     implementation(libs.androidx.core.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,10 +56,12 @@ android {
 
         // Set the values from local.properties
         val isDevModeEnabled = parseBoolean(localProperties.getProperty("config.isDevModeEnabled"), false)
+        val isHttpLoggingEnabled = parseBoolean(localProperties.getProperty("config.isHttpLoggingEnabled"), false)
         val apiBaseUrl = localProperties.getProperty("api.baseUrl")
 
         // Set the buildConfigField
         buildConfigField("Boolean", "IS_DEV_MODE_ENABLED", isDevModeEnabled.toString())
+        buildConfigField("Boolean", "IS_HTTP_LOGGING_ENABLED", isHttpLoggingEnabled.toString())
         buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
         buildConfigField("Boolean", "IS_DEV_MODE_ENABLED", isDevModeEnabled.toString())
         buildConfigField("Boolean", "IS_HTTP_LOGGING_ENABLED", isHttpLoggingEnabled.toString())
         buildConfigField("String", "API_BASE_URL", "\"$apiBaseUrl\"")
+            ?: throw GradleException("API_BASE_URL is not set in local.properties")
     }
 
     buildTypes {

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/Constants.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/Constants.kt
@@ -7,4 +7,6 @@ object Constants {
     const val MIN_OPTIONS = 2
     const val MAX_PARTICIPANTS = 10
     const val MIN_PARTICIPANTS = 3
+
+    const val NO_AUTH_HEADER = "No-Authentication"
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/AuthInterceptor.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/AuthInterceptor.kt
@@ -1,0 +1,52 @@
+package com.imeanttobe.consensusapp.data.interceptors
+
+import com.imeanttobe.consensusapp.core.Constants
+import com.imeanttobe.consensusapp.data.repo.IdRepo
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val idRepo: IdRepo
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        // Intercept current request
+        val request = chain.request()
+        lateinit var newRequest: Request
+
+        // Check if the request contains our custom "No-Authentication" header
+        val isPublicApi = request.header(Constants.NO_AUTH_HEADER) != null
+        if (isPublicApi) {
+            // 1. If it's public, remove the marker header so the server doesn't see it
+            // 2. Do NOT add X-User-Id
+            newRequest = request.newBuilder()
+                .removeHeader("No-Authentication")
+                .build()
+        } else {
+            // 1. Get the current User ID using runBlocking
+            // This blocks the network thread until the ID is retrieved from disk
+            val userIdRequest = runBlocking {
+                idRepo.getId()
+            }
+            lateinit var userId: String
+
+            // 2. Check whether the request for id is successful
+            if (userIdRequest.isSuccess) {
+                val tempUserId = userIdRequest.getOrNull()
+                userId = tempUserId ?: ""
+            } else {
+                userId = ""
+            }
+
+            // 3. Create the new request with the header
+            newRequest = request.newBuilder()
+                .header("X-User-Id", userId ?: "")
+                .build()
+        }
+
+        // Proceed
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/AuthInterceptor.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/AuthInterceptor.kt
@@ -22,7 +22,7 @@ class AuthInterceptor @Inject constructor(
             // 1. If it's public, remove the marker header so the server doesn't see it
             // 2. Do NOT add X-User-Id
             newRequest = request.newBuilder()
-                .removeHeader("No-Authentication")
+                .removeHeader(Constants.NO_AUTH_HEADER)
                 .build()
         } else {
             // 1. Get the current User ID using runBlocking

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/LoggingInterceptor.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/interceptors/LoggingInterceptor.kt
@@ -1,0 +1,43 @@
+package com.imeanttobe.consensusapp.data.interceptors
+
+import android.util.Log
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class LoggingInterceptor : Interceptor {
+    companion object {
+        private const val TAG = "API_LOG"
+        private const val MAX_BYTES_TO_READ = 1024L // Read only first 1KB
+    }
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        // 1. Log Request Details
+        Log.d(TAG, "--> ${request.method} ${request.url}")
+
+        val startNs = System.nanoTime()
+        val response: Response
+        try {
+            response = chain.proceed(request)
+        } catch (e: Exception) {
+            Log.e(TAG, "<-- HTTP FAILED: $e")
+            throw e
+        }
+        val tookMs = (System.nanoTime() - startNs) / 1e6
+
+        // 2. Log Response Details
+        Log.d(TAG, "<-- ${response.code} ${response.message} (${tookMs}ms)")
+
+        // 3. Log a small portion of the body safely
+        // 'peekBody' clones the stream so the original remains valid for Retrofit
+        val peekedBody = response.peekBody(MAX_BYTES_TO_READ)
+
+        Log.d(TAG, "Body (First $MAX_BYTES_TO_READ bytes): ${peekedBody.string()}")
+        Log.d(TAG, "<-- END HTTP")
+
+        return response
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
@@ -1,4 +1,4 @@
-package com.imeanttobe.consensusapp.core
+package com.imeanttobe.consensusapp.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class HiltModule {
+abstract class DataStoreModule {
     companion object {
         @Provides
         @Singleton

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -20,7 +20,7 @@ object NetworkModule {
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor
     ): OkHttpClient {
-        val isHttpLoggingEnabled = true
+        val isHttpLoggingEnabled = BuildConfig.IS_HTTP_LOGGING_ENABLED
 
         return OkHttpClient.Builder()
             .apply {

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.imeanttobe.consensusapp.di
 
+import com.imeanttobe.consensusapp.BuildConfig
 import com.imeanttobe.consensusapp.data.interceptors.AuthInterceptor
 import com.imeanttobe.consensusapp.data.interceptors.LoggingInterceptor
 import dagger.Module
@@ -7,6 +8,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
 
 @Module
@@ -29,6 +32,16 @@ object NetworkModule {
                     addInterceptor(LoggingInterceptor())
                 }
             }
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.API_BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -6,14 +6,14 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import jakarta.inject.Singleton
 import okhttp3.OkHttpClient
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
     @Provides
-    @Singleton
+//    @Singleton
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor
     ): OkHttpClient {

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -1,0 +1,34 @@
+package com.imeanttobe.consensusapp.di
+
+import com.imeanttobe.consensusapp.data.interceptors.AuthInterceptor
+import com.imeanttobe.consensusapp.data.interceptors.LoggingInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jakarta.inject.Singleton
+import okhttp3.OkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        authInterceptor: AuthInterceptor
+    ): OkHttpClient {
+        val isHttpLoggingEnabled = true
+
+        return OkHttpClient.Builder()
+            .apply {
+                // Attach auth interceptor
+                addInterceptor(authInterceptor)
+
+                // Attach http logging interceptor when it is enabled
+                if (isHttpLoggingEnabled) {
+                    addInterceptor(LoggingInterceptor())
+                }
+            }
+            .build()
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
     @Provides
-//    @Singleton
+    @Singleton
     fun provideOkHttpClient(
         authInterceptor: AuthInterceptor
     ): OkHttpClient {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,9 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.0"
-composeBom = "2025.11.01"
-material3 = "1.5.0-alpha09"
+activityCompose = "1.12.1"
+composeBom = "2025.12.00"
+material3 = "1.5.0-alpha10"
 
 # Hilt
 ksp = "2.2.21-2.0.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,9 @@ protobufKotlin = "4.33.1"
 protobuf = "0.9.5"
 datastore = "1.2.0"
 
+# Network
+retrofit2 = "3.0.0"
+
 # Global
 serialization = "1.9.0"
 mockk = "1.14.6"
@@ -56,6 +59,10 @@ dagger-hilt-android-testing = { group = "com.google.dagger", name = "hilt-androi
 datastore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "datastore" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobufKotlin" }
+
+# Network
+squareup-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit2" }
+squareup-retrofit2-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit2" }
 
 # Global
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #21 

# 📝 작업 내용
API 요청을 주고받기 위해 필요한 라이브러리인 Retrofit2를 도입하고, HTTP 요청을 처리하기 위해 인터셉터를 2종 추가했어요.

## 일반
- [x] Retrofit2 및 JSON 직렬화를 위한 GSON 컨버터 도입
- [x] 네트워크 기능만을 위한 Hilt 모듈 추가
- [x] 기존 `HiltModule`의 파일 위치를 옮기고 파일 이름을 `DataStoreModule`로 변경하여 도메인 특정

## 인터셉터 추가
- [x] HTTP 요청 및 응답 로깅을 위한 `LoggingInterceptor` 구현
- [x] 인증 요청을 위한 `AuthInterceptor` 구현
- [x] 인증 요청을 위한 헤더가 API에 따라 선택적으로 추가되도록 개선

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 HTTP 로깅 토글 추가
  * API 기본 URL 런타임 구성 및 빌드 시 필수화
  * 공개/비공개 요청 구분에 따른 인증 헤더 자동 처리
  * 요청/응답 메타데이터 및 일부 응답 내용 로깅 추가
  * NO_AUTH_HEADER 상수 추가

* **Chores**
  * 의존성 정리 및 Proto Datastore/Retrofit 라이브러리 통합 추가
  * CI에 로컬 설정 준비 단계 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->