### PR TITLE
[FEAT] 투표 API 구현

### DIFF
--- a/app/src/androidTest/java/com/imeanttobe/consensusapp/data/repo/IdRepoTest.kt
+++ b/app/src/androidTest/java/com/imeanttobe/consensusapp/data/repo/IdRepoTest.kt
@@ -3,7 +3,7 @@ package com.imeanttobe.consensusapp.data.repo
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.imeanttobe.consensusapp.data.serializer.idDataStore
+import com.imeanttobe.consensusapp.data.local.serializer.idDataStore
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/IdSerializer.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/IdSerializer.kt
@@ -1,4 +1,4 @@
-package com.imeanttobe.consensusapp.data.serializer
+package com.imeanttobe.consensusapp.data.local.serializer
 
 import android.content.Context
 import androidx.datastore.core.CorruptionException

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/api/PollApi.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/api/PollApi.kt
@@ -23,28 +23,28 @@ interface PollApi {
 
     @PATCH("api/polls/{id}/finish")
     suspend fun finishPoll(
-        @Path("id") id: String
+        @Path("id") id: Int
     ): Response<FinishPollResponse>
 
     @PATCH("api/polls/{id}/vote")
     suspend fun votePoll(
-        @Path("id") id: String,
+        @Path("id") id: Int,
         @Body request: VoteRequest
     ): Response<Unit>
 
     @PATCH("api/polls/{id}/submit")
     suspend fun submitPollResult(
-        @Path("id") id: String,
+        @Path("id") id: Int,
         @Body request: SubmitPollResultRequest
     ): Response<SubmitPollResultResponse>
 
     @GET("api/polls/{id}")
     suspend fun getPoll(
-        @Path("id") id: String
+        @Path("id") id: Int
     ): Response<GetPollResponse>
 
     @GET("api/polls/{id}/result")
     suspend fun getPollResult(
-        @Path("id") id: String
+        @Path("id") id: Int
     ): Response<GetPollResultResponse>
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/CreatePollResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/CreatePollResponse.kt
@@ -25,4 +25,20 @@ data class CreatePollResponse(
 
     @SerializedName("deepLink")
     val deepLink: String
-)
+) {
+    companion object {
+        fun getFakeData(): CreatePollResponse {
+            return CreatePollResponse(
+                id = 1,
+                title = "Test Poll",
+                candidates = listOf(
+                    "Candidate 1",
+                    "Candidate 2",
+                    "Candidate 3"
+                ),
+                codes = listOf("ABCD", "EFGH", "IJKL"),
+                deepLink = "consensus://poll/1"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/FinishPollResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/FinishPollResponse.kt
@@ -9,4 +9,16 @@ import com.google.gson.annotations.SerializedName
 data class FinishPollResponse(
     @SerializedName("votes")
     val votes: List<String>
-)
+) {
+    companion object {
+        fun getFakeData(): FinishPollResponse {
+            return FinishPollResponse(
+                listOf(
+                    "encrypted_vote_1",
+                    "encrypted_vote_2",
+                    "encrypted_vote_3"
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResponse.kt
@@ -21,4 +21,15 @@ data class GetPollResponse(
 
     @SerializedName("pk")
     val pk: String
-)
+) {
+    companion object {
+        fun getFakeData(): GetPollResponse {
+            return GetPollResponse(
+                title = "Title",
+                id = 1,
+                candidates = listOf("Candidate 1", "Candidate 2"),
+                pk = "pk"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
@@ -21,4 +21,15 @@ data class GetPollResultResponse(
 
     @SerializedName("votes")
     val votes: List<Int>
-)
+) {
+    companion object {
+        fun getFakeData(): GetPollResultResponse {
+            return GetPollResultResponse(
+                title = "Title",
+                id = 1,
+                candidates = listOf("Candidate 1", "Candidate 2"),
+                votes = listOf(1, 2)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/SubmitPollResultResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/SubmitPollResultResponse.kt
@@ -17,4 +17,18 @@ data class SubmitPollResultResponse(
 
     @SerializedName("votes")
     val votes: List<Int>
-)
+) {
+    companion object {
+        fun getFakeData(): SubmitPollResultResponse {
+            return SubmitPollResultResponse(
+                id = 1,
+                candidates = listOf(
+                    "Candidate 1",
+                    "Candidate 2",
+                    "Candidate 3"
+                ),
+                votes = listOf(10, 20, 30),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/interceptor/AuthInterceptor.kt
@@ -1,7 +1,7 @@
 package com.imeanttobe.consensusapp.data.remote.interceptor
 
 import com.imeanttobe.consensusapp.core.Constants
-import com.imeanttobe.consensusapp.data.repo.IdRepo
+import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
@@ -1,0 +1,42 @@
+package com.imeanttobe.consensusapp.data.repo
+
+import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+
+class FakePollRepoImpl : PollRepo {
+    override suspend fun createPoll(
+        title: String,
+        candidates: List<String>
+    ): Result<CreatePollResponse> {
+        return Result.success(CreatePollResponse.getFakeData())
+    }
+
+    override suspend fun getPoll(id: Int): Result<GetPollResponse> {
+        return Result.success(GetPollResponse.getFakeData())
+    }
+
+    override suspend fun vote(
+        id: Int,
+        vote: String,
+        code: String
+    ): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun finishPoll(id: Int): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun getPollResult(id: Int): Result<GetPollResultResponse> {
+        return Result.success(GetPollResultResponse.getFakeData())
+    }
+
+    override suspend fun submitPollResult(
+        id: Int,
+        votes: List<Int>
+    ): Result<Unit> {
+        return Result.success(Unit)
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/IdRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/IdRepoImpl.kt
@@ -2,6 +2,7 @@ package com.imeanttobe.consensusapp.data.repo
 
 import androidx.datastore.core.DataStore
 import com.imeanttobe.consensusapp.Id
+import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -18,8 +18,10 @@ class PollRepoImpl @Inject constructor(
             val response = pollApi.getPoll(id)
 
             if (response.isSuccessful) {
-                if (response.body() != null) {
-                    Result.success(response.body()!!)
+                val body = response.body()
+
+                if (body != null) {
+                    Result.success(body)
                 } else {
                     Result.failure(Exception("Response body is null"))
                 }
@@ -51,7 +53,9 @@ class PollRepoImpl @Inject constructor(
             val response = pollApi.getPollResult(id)
 
             if (response.isSuccessful) {
-                if (response.body() != null) {
+                val body = response.body()
+
+                if (body != null) {
                     Result.success(response.body()!!)
                 } else {
                     Result.failure(Exception("Response body is null"))
@@ -90,8 +94,10 @@ class PollRepoImpl @Inject constructor(
             val response = pollApi.createPoll(request)
 
             if (response.isSuccessful) {
-                if (response.body() != null) {
-                    Result.success(response.body()!!)
+                val body = response.body()
+
+                if (body != null) {
+                    Result.success(body)
                 } else {
                     Result.failure(Exception("Response body is null"))
                 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -56,7 +56,7 @@ class PollRepoImpl @Inject constructor(
                 val body = response.body()
 
                 if (body != null) {
-                    Result.success(response.body()!!)
+                    Result.success(body)
                 } else {
                     Result.failure(Exception("Response body is null"))
                 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -1,0 +1,119 @@
+package com.imeanttobe.consensusapp.data.repo
+
+import com.imeanttobe.consensusapp.data.remote.api.PollApi
+import com.imeanttobe.consensusapp.data.remote.dto.CreatePollRequest
+import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultRequest
+import com.imeanttobe.consensusapp.data.remote.dto.VoteRequest
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import javax.inject.Inject
+
+class PollRepoImpl @Inject constructor(
+    private val pollApi: PollApi
+): PollRepo {
+    override suspend fun getPoll(id: Int): Result<GetPollResponse> {
+        return try {
+            val response = pollApi.getPoll(id)
+
+            if (response.isSuccessful) {
+                if (response.body() != null) {
+                    Result.success(response.body()!!)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun vote(id: Int, vote: String, code: String): Result<Unit> {
+        return try {
+            val request = VoteRequest(vote, code)
+            val response = pollApi.votePoll(id, request)
+
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getPollResult(id: Int): Result<GetPollResultResponse> {
+        return try {
+            val response = pollApi.getPollResult(id)
+
+            if (response.isSuccessful) {
+                if (response.body() != null) {
+                    Result.success(response.body()!!)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit> {
+        return try {
+            val request = SubmitPollResultRequest(votes)
+            val response = pollApi.submitPollResult(id, request)
+
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun createPoll(
+        title: String,
+        candidates: List<String>
+    ): Result<CreatePollResponse> {
+        val pk = "" // TODO: have to generate pk here
+
+        return try {
+            val request = CreatePollRequest(title, pk, candidates)
+            val response = pollApi.createPoll(request)
+
+            if (response.isSuccessful) {
+                if (response.body() != null) {
+                    Result.success(response.body()!!)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun finishPoll(id: Int): Result<Unit> {
+        return try {
+            val response = pollApi.finishPoll(id)
+
+            if (response.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
@@ -5,7 +5,7 @@ import androidx.datastore.core.DataStore
 import com.imeanttobe.consensusapp.Id
 import com.imeanttobe.consensusapp.data.repo.IdRepo
 import com.imeanttobe.consensusapp.data.repo.IdRepoImpl
-import com.imeanttobe.consensusapp.data.serializer.idDataStore
+import com.imeanttobe.consensusapp.data.local.serializer.idDataStore
 import dagger.Binds
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/DataStoreModule.kt
@@ -3,7 +3,7 @@ package com.imeanttobe.consensusapp.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import com.imeanttobe.consensusapp.Id
-import com.imeanttobe.consensusapp.data.repo.IdRepo
+import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import com.imeanttobe.consensusapp.data.repo.IdRepoImpl
 import com.imeanttobe.consensusapp.data.local.serializer.idDataStore
 import dagger.Binds

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.imeanttobe.consensusapp.di
 
 import com.imeanttobe.consensusapp.BuildConfig
+import com.imeanttobe.consensusapp.data.remote.api.PollApi
 import com.imeanttobe.consensusapp.data.remote.interceptor.AuthInterceptor
 import com.imeanttobe.consensusapp.data.remote.interceptor.LoggingInterceptor
 import dagger.Module
@@ -43,5 +44,11 @@ object NetworkModule {
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
+    }
+
+    @Provides
+    @Singleton
+    fun providePollApi(retrofit: Retrofit): PollApi {
+        return retrofit.create(PollApi::class.java)
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/IdRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/IdRepo.kt
@@ -1,4 +1,4 @@
-package com.imeanttobe.consensusapp.data.repo
+package com.imeanttobe.consensusapp.domain.repo
 
 interface IdRepo {
     suspend fun getId(): Result<String>

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
@@ -1,0 +1,15 @@
+package com.imeanttobe.consensusapp.domain.repo
+
+import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+
+interface PollRepo {
+    suspend fun getPoll(id: Int): Result<GetPollResponse>
+    suspend fun vote(id: Int, vote: String, code: String): Result<Unit>
+    suspend fun finishPoll(id: Int): Result<Unit>
+    suspend fun getPollResult(id: Int): Result<GetPollResultResponse>
+    suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit>
+    // Public key will be given in actual impl
+    suspend fun createPoll(title: String, candidates: List<String>): Result<CreatePollResponse>
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/dev/DevViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/dev/DevViewModel.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.imeanttobe.consensusapp.data.repo.IdRepo
+import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.imeanttobe.consensusapp.core.UiState
-import com.imeanttobe.consensusapp.data.repo.IdRepo
+import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.util.UUID


### PR DESCRIPTION
# 🚩 연관 이슈

closed #20 

# 📝 작업 내용
투표 API 요청을 위해 저장소 인터페이스와 저장소 구현체를 추가했어요. 또한, 추후 테스트 용이성을 위해 모방된 응답을 반환하는 가짜 저장소 구현체도 추가했어요.

## 투표 API 구현
- [x] 투표 API 저장소 인터페이스 구현
- [x] 투표 API 저장소 구현체 구현
- [x] 가짜 투표 API 저장소 구현체 구현

## 그 외 변경 사항
- [x] 저장소 인터페이스를 /data/repo에서 /domain/repo로 이동
- [x] 투표 API의 ID 필드 타입이 `String`로 지정되어 있던 오류 수정 (`Int`로 변경)

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 프로젝트 구조 및 패키지 구성 정리(패키지 이동 및 경로 정리)
  * 투표 식별자(id) 타입을 String에서 Int로 표준화

* **새 기능**
  * 네트워크(API) 제공 바인딩 추가(앱 내 Poll API 등록)

* **테스트**
  * 테스트/개발용 페이크 저장소 및 응답 생성기 추가(모의 데이터 제공)

* **작업**
  * DI 모듈 및 저장소 관련 정리 완료

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->