### PR TITLE
[CHORE] PR 병합 후 CI가 실행되지 않게 수정

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,6 @@
 name: Android CI
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
# 🚩 연관 이슈

closed #39 

# 📝 작업 내용
현재 모든 CI가 통과된 것을 확인한 후에 PR을 병합하기 때문에 모든 브랜치는 제대로 동작할 것이 보장된 상태임에도 불구하고, 여전히 병합후 불필요한 CI가 실행되고 있어요. 자원 낭비를 줄이기 위해 CI 조건에서 `push`를 제거했습니다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음