### PR TITLE
[REFACTOR] 스플래시 뷰 모델 자료형을 `MutableStateFlow`로 변경

### DIFF
--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.core.findActivity
@@ -35,14 +36,17 @@ fun SplashScreen(
 ) {
     val context = LocalContext.current
 
-    LaunchedEffect(key1 = viewModel.splashState.value) {
-        if (viewModel.splashState.value is UiState.Success) {
+    val splashState = viewModel.splashState.collectAsStateWithLifecycle()
+    val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(key1 = splashState.value) {
+        if (splashState.value is UiState.Success) {
             navController.navigate(Route.DevRoute) {
                 popUpTo(Route.SplashScreen) {
                     inclusive = true
                 }
             }
-        } else if (viewModel.splashState.value is UiState.Failure) {
+        } else if (splashState.value is UiState.Failure) {
             viewModel.setDialogState(true)
         }
     }
@@ -68,7 +72,7 @@ fun SplashScreen(
         }
     }
 
-    if (viewModel.dialogState.value) {
+    if (dialogState.value) {
         AlertDialog(
             onDismissRequest = {  },
             icon = { Icon(imageVector = Icons.Outlined.Warning, contentDescription = null) },

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
@@ -40,27 +40,21 @@ class SplashViewModel @Inject constructor(
 
                if (isExist.isSuccess) {
                    if (isExist.getOrDefault(false)) {
-                       Log.d("Consensus", "# ID exists.")
                        _splashState.value = UiState.Success(Unit)
                    } else {
-                       Log.d("Consensus", "# ID does not exists.")
                        val id = UUID.randomUUID().toString()
                        val result = idRepo.setId(id)
 
                        if (result.isSuccess) {
-                           Log.d("Consensus", "# Successfully created new id.")
                            _splashState.value = UiState.Success(Unit)
                        } else {
-                           Log.e("Consensus", "# Failed to create new id.")
                            _splashState.value = UiState.Failure(result.exceptionOrNull()?.message ?: "새로 생성된 ID를 쓰던 중 오류 발생")
                        }
                    }
                } else {
-                   Log.e("Consensus", "# Failed to check whether the id is exists.")
                    _splashState.value = UiState.Failure(isExist.exceptionOrNull()?.message ?: "ID를 확인하는 중 오류 발생")
                }
            } catch (e: Exception) {
-               Log.e("Consensus", "# Failed to check while generating id.")
                _splashState.value = UiState.Failure(e.message ?: "ID를 설정하는 중 오류 발생")
            }
        }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
@@ -1,12 +1,13 @@
 package com.imeanttobe.consensusapp.ui.splash
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.domain.repo.IdRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
@@ -15,11 +16,11 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
     private val idRepo: IdRepo,
 ) : ViewModel() {
-    private val _splashState = mutableStateOf<UiState<Unit>>(UiState.Idle)
-    val splashState: State<UiState<Unit>> = _splashState
+    private val _splashState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
+    val splashState: StateFlow<UiState<Unit>> = _splashState
 
-    private val _dialogState = mutableStateOf<Boolean>(false)
-    val dialogState: State<Boolean> = _dialogState
+    private val _dialogState = MutableStateFlow<Boolean>(false)
+    val dialogState: StateFlow<Boolean> = _dialogState
 
     init {
         checkAndGenerateId()
@@ -32,27 +33,34 @@ class SplashViewModel @Inject constructor(
     fun checkAndGenerateId() {
        viewModelScope.launch {
            _splashState.value = UiState.Loading
+           Log.d("Consensus", "# checkAndGenerateId called.")
 
            try {
                val isExist = idRepo.isExist()
 
                if (isExist.isSuccess) {
                    if (isExist.getOrDefault(false)) {
+                       Log.d("Consensus", "# ID exists.")
                        _splashState.value = UiState.Success(Unit)
                    } else {
+                       Log.d("Consensus", "# ID does not exists.")
                        val id = UUID.randomUUID().toString()
                        val result = idRepo.setId(id)
 
                        if (result.isSuccess) {
+                           Log.d("Consensus", "# Successfully created new id.")
                            _splashState.value = UiState.Success(Unit)
                        } else {
+                           Log.e("Consensus", "# Failed to create new id.")
                            _splashState.value = UiState.Failure(result.exceptionOrNull()?.message ?: "새로 생성된 ID를 쓰던 중 오류 발생")
                        }
                    }
                } else {
+                   Log.e("Consensus", "# Failed to check whether the id is exists.")
                    _splashState.value = UiState.Failure(isExist.exceptionOrNull()?.message ?: "ID를 확인하는 중 오류 발생")
                }
            } catch (e: Exception) {
+               Log.e("Consensus", "# Failed to check while generating id.")
                _splashState.value = UiState.Failure(e.message ?: "ID를 설정하는 중 오류 발생")
            }
        }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #42 

# 📝 작업 내용
스플래시 화면의 뷰 모델 자료형을 Compose에 의존하는 `mutableStateOf`에서 Kotlin만 있으면 되는 `MutableStateFlow`로 대체했어요.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 스플래시 화면 상태 관리가 개선되어 초기 로딩과 상태 전환이 더 안정적으로 동작합니다.
  * 팝업(알림) 표시 제어가 더 예측 가능하게 개선되었습니다.
* **진단·모니터링**
  * 실행 흐름 로그가 강화되어 문제 원인 파악과 진단이 쉬워졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->