### PR TITLE
[FEAT] SEAL BGV 키 생성 함수 구현

### DIFF
--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -24,6 +24,9 @@ static unique_ptr<BatchEncoder> g_encoder;
 static unique_ptr<PublicKey>    g_public_key;
 static unique_ptr<SecretKey>    g_secret_key;
 
+// Constants
+static const string PATH_SEAL_KEYS_CLASS = "com/imeanttobe/consensusapp/seal/SealKeys";
+
 // JNI Functions
 // - Sample function
 extern "C" JNIEXPORT jstring JNICALL
@@ -70,7 +73,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject
 }
 
 // - Key generation function
-extern "C" JNIEXPORT jbyteArray JNICALL
+extern "C" JNIEXPORT jobject JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobject) {
     if (!g_context) {
         return nullptr;
@@ -89,16 +92,34 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
         g_encryptor = make_unique<Encryptor>(*g_context, *g_public_key);
         g_decryptor = make_unique<Decryptor>(*g_context, *g_secret_key);
 
-        // Serialize keys
-        stringstream data_stream;
-        g_public_key->save(data_stream);
-        string serialized_key = data_stream.str();
+        // Serialize pk
+        stringstream pk_stream;
+        g_public_key->save(pk_stream);
+        string serialized_pk = pk_stream.str();
 
-        // Convert to jbyteArray
-        jbyteArray result = env->NewByteArray(static_cast<jsize>(serialized_key.size()));
-        env->SetByteArrayRegion(result, 0, serialized_key.size(), reinterpret_cast<const jbyte*>(serialized_key.c_str()));
+        // Convert pk to jbyteArray
+        jbyteArray pk_bytes = env->NewByteArray(static_cast<jsize>(serialized_pk.size()));
+        env->SetByteArrayRegion(pk_bytes, 0, static_cast<jsize>(serialized_pk.size()), reinterpret_cast<const jbyte*>(serialized_pk.c_str()));
 
-        return result;
+        // Serialize sk
+        stringstream sk_stream;
+        g_secret_key->save(sk_stream);
+        string serialized_sk = sk_stream.str();
+
+        // Convert sk to jbyteArray
+        jbyteArray sk_bytes = env->NewByteArray(static_cast<jsize>(serialized_sk.size()));
+        env->SetByteArrayRegion(sk_bytes, 0, static_cast<jsize>(serialized_sk.size()), reinterpret_cast<const jbyte*>(serialized_sk.c_str()));
+
+        // Find SealKeys class
+        jclass seal_keys_class = env->FindClass(PATH_SEAL_KEYS_CLASS.c_str());
+
+        // Find constructor
+        jmethodID constructor = env->GetMethodID(seal_keys_class, "<init>", "([B[B)V");
+
+        // Create Java object
+        jobject seal_keys = env->NewObject(seal_keys_class, constructor, pk_bytes, sk_bytes);
+
+        return seal_keys;
     } catch (const exception &e) {
         __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Error in generateKeys: %s", e.what());
         return nullptr;

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -33,7 +33,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_stringFromJNI(JNIEnv *env,
     return env->NewStringUTF(hello.c_str());
 }
 
-// - Init and key generation function
+// - Init function
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject) {
     try {
@@ -66,5 +66,44 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject
     } catch (...) {
         __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Unknown error in init");
         return JNI_FALSE;
+    }
+}
+
+// - Key generation function
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobject) {
+    if (!g_context) {
+        return nullptr;
+    }
+
+    try {
+        // Create KeyGenerator
+        g_keygen = make_unique<KeyGenerator>(*g_context);
+
+        // Create SK, PK
+        g_secret_key = make_unique<SecretKey>(g_keygen->secret_key());
+        g_public_key = make_unique<PublicKey>();
+        g_keygen->create_public_key(*g_public_key);
+
+        // Create encryptor and decryptor
+        g_encryptor = make_unique<Encryptor>(*g_context, *g_public_key);
+        g_decryptor = make_unique<Decryptor>(*g_context, *g_secret_key);
+
+        // Serialize keys
+        stringstream data_stream;
+        g_public_key->save(data_stream);
+        string serialized_key = data_stream.str();
+
+        // Convert to jbyteArray
+        jbyteArray result = env->NewByteArray(static_cast<jsize>(serialized_key.size()));
+        env->SetByteArrayRegion(result, 0, serialized_key.size(), reinterpret_cast<const jbyte*>(serialized_key.c_str()));
+
+        return result;
+    } catch (const exception &e) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Error in generateKeys: %s", e.what());
+        return nullptr;
+    } catch (...) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Unknown error in generateKeys");
+        return nullptr;
     }
 }

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -80,8 +80,10 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
     }
 
     try {
-        // Create KeyGenerator
-        g_keygen = make_unique<KeyGenerator>(*g_context);
+        // Check whether key generator is exist
+        if (!g_keygen) {
+            g_keygen = make_unique<KeyGenerator>(*g_context);
+        }
 
         // Create SK, PK
         g_secret_key = make_unique<SecretKey>(g_keygen->secret_key());
@@ -112,9 +114,17 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
 
         // Find SealKeys class
         jclass seal_keys_class = env->FindClass(PATH_SEAL_KEYS_CLASS.c_str());
+        if (seal_keys_class == nullptr) {
+            __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Failed to find SealKeys class.");
+            return nullptr;
+        }
 
         // Find constructor
         jmethodID constructor = env->GetMethodID(seal_keys_class, "<init>", "([B[B)V");
+        if (constructor == nullptr) {
+            __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Failed to find constructor.");
+            return nullptr;
+        }
 
         // Create Java object
         jobject seal_keys = env->NewObject(seal_keys_class, constructor, pk_bytes, sk_bytes);

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -11,11 +11,11 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_stringFromJNI(JNIEnv *env, jobje
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject);
 
-/*
 // Create PK and SK
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobject);
 
+/*
 // Load given PK on native side
 extern "C" JNIEXPORT void JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_loadPublicKey(JNIEnv *env, jobject, jbyteArray pkBytes);

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -12,7 +12,7 @@ extern "C" JNIEXPORT jboolean JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject);
 
 // Create PK and SK
-extern "C" JNIEXPORT jbyteArray JNICALL
+extern "C" JNIEXPORT jobject JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobject);
 
 /*

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -7,4 +7,5 @@ object NativeLib {
 
     external fun stringFromJNI(): String
     external fun initContext(): Boolean
+    external fun generateKeys(): ByteArray
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -7,5 +7,5 @@ object NativeLib {
 
     external fun stringFromJNI(): String
     external fun initContext(): Boolean
-    external fun generateKeys(): ByteArray
+    external fun generateKeys(): SealKeys
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -7,5 +7,5 @@ object NativeLib {
 
     external fun stringFromJNI(): String
     external fun initContext(): Boolean
-    external fun generateKeys(): SealKeys
+    external fun generateKeys(): SealKeys?
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/SealKeys.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/SealKeys.kt
@@ -1,0 +1,21 @@
+package com.imeanttobe.consensusapp.seal
+
+data class SealKeys(
+    val pk: ByteArray,
+    val sk: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as SealKeys
+        if (!pk.contentEquals(other.pk)) return false
+        if (!sk.contentEquals(other.sk)) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = pk.contentHashCode()
+        result = 31 * result + sk.contentHashCode()
+        return result
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #36 

# 📝 작업 내용
SEAL의 BGV 스킴 키 생성 함수를 구현했어요.

## 세부 구현 사항
- [x] 한 사용자가 여러 투표를 개최하는 것을 고려하여, PK와 SK를 모두 처리할 수 있는 클래스 `SealKeys` 추가
- [x] 키 생성 함수를 C++ 측에 추가
- [x] 브릿지를 Kotlin 측에 추가 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱에서 암호화 키를 생성하고 반환하는 기능이 추가되었습니다. 생성된 공개키/비밀키를 하나의 키 객체로 받아 활용할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->