### PR TITLE
[FEAT] Android 수준 투표 키 저장 기능 구현

### DIFF
--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
@@ -1,0 +1,106 @@
+package com.imeanttobe.consensusapp.core.crypto
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CryptoManager @Inject constructor() {
+    companion object {
+        // Define the constants for the encryption algorithm and key alias
+        private const val KEY_ALIAS = "CONSENSUS_MASTER_KEY"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
+        private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_GCM
+        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_NONE
+        private const val KEY_SIZE = 256
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val IV_SIZE = 12
+
+    }
+
+    // Keystore instance
+    private val keyStore by lazy {
+        try {
+            KeyStore.getInstance(ANDROID_KEYSTORE).apply {
+                load(null)
+            }
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to load Android KeyStore", e)
+        }
+    }
+
+    /**
+     * Android Keystore에 저장된 키를 가져오거나, 없다면 새로 생성합니다.
+     */
+    private fun getOrCreateKey(): SecretKey {
+        // 1. Try to get the key
+        val existingKey = keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry
+
+        // 2. If key exists, return it
+        if (existingKey != null) {
+            return existingKey.secretKey
+        }
+
+        // 3. Else, prepare key generation spec
+        val paramsBuilder = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+        paramsBuilder.apply {
+            setBlockModes(BLOCK_MODE)
+            setEncryptionPaddings(PADDING)
+            setKeySize(KEY_SIZE)
+            setRandomizedEncryptionRequired(true)
+        }
+
+        // 4. Generate key with the spec
+        val keyGenerator = KeyGenerator.getInstance(ALGORITHM, ANDROID_KEYSTORE)
+        keyGenerator.init(paramsBuilder.build())
+        return keyGenerator.generateKey()
+    }
+
+    fun encrypt(plainText: ByteArray): EncryptionResult {
+        // 0. Check whether plainText is not empty
+        require(plainText.isNotEmpty()) { "Plain text cannot be empty" }
+
+        // 1. Load cipher instance
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+
+        // 2. Init cipher with encryption mode
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+
+        // 3. Return encrypted text and IV
+        return EncryptionResult(cipher.doFinal(plainText), cipher.iv)
+    }
+
+    fun decrypt(ciphertext: ByteArray, iv: ByteArray): ByteArray {
+        require(ciphertext.isNotEmpty()) { "Encrypted text cannot be empty" }
+        require(iv.isNotEmpty()) { "IV cannot be empty" }
+        require(iv.size == IV_SIZE) { "IV must be $IV_SIZE bytes" }
+
+        try {
+            // 1. Load cipher instance and prepare variables
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val spec = GCMParameterSpec(128, iv)
+
+            // 2. Init cipher with decryption mode
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), spec)
+
+            // 3. Return decrypted text
+            return cipher.doFinal(ciphertext)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to decrypt data", e)
+        }
+    }
+
+    fun decrypt(encryptionResult: EncryptionResult): ByteArray {
+        return decrypt(encryptionResult.ciphertext, encryptionResult.iv)
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
@@ -70,14 +70,18 @@ class CryptoManager @Inject constructor() {
         // 0. Check whether plainText is not empty
         require(plainText.isNotEmpty()) { "Plain text cannot be empty" }
 
-        // 1. Load cipher instance
-        val cipher = Cipher.getInstance(TRANSFORMATION)
+        try {
+            // 1. Load cipher instance
+            val cipher = Cipher.getInstance(TRANSFORMATION)
 
-        // 2. Init cipher with encryption mode
-        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+            // 2. Init cipher with encryption mode
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
 
-        // 3. Return encrypted text and IV
-        return EncryptionResult(cipher.doFinal(plainText), cipher.iv)
+            // 3. Return encrypted text and IV
+            return EncryptionResult(cipher.doFinal(plainText), cipher.iv)
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to encrypt data", e)
+        }
     }
 
     fun decrypt(ciphertext: ByteArray, iv: ByteArray): ByteArray {

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/CryptoManager.kt
@@ -3,6 +3,7 @@ package com.imeanttobe.consensusapp.core.crypto
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import java.security.KeyStore
+import javax.crypto.AEADBadTagException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -99,6 +100,8 @@ class CryptoManager @Inject constructor() {
 
             // 3. Return decrypted text
             return cipher.doFinal(ciphertext)
+        } catch (e: AEADBadTagException) {
+            throw SecurityException("Decryption failed: Invalid ciphertext or IV")
         } catch (e: Exception) {
             throw IllegalStateException("Failed to decrypt data", e)
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
@@ -20,6 +20,6 @@ data class EncryptionResult(
     }
 
     override fun toString(): String {
-        return "EncryptionResult(ciphertext=${ciphertext.contentToString()} bytes, iv=${iv.contentToString()} bytes)"
+        return "EncryptionResult(ciphertext=${ciphertext.size} bytes, iv=${iv.size} bytes)"
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
@@ -1,0 +1,21 @@
+package com.imeanttobe.consensusapp.core.crypto
+
+data class EncryptionResult(
+    val ciphertext: ByteArray,
+    val iv: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as EncryptionResult
+        if (!ciphertext.contentEquals(other.ciphertext)) return false
+        if (!iv.contentEquals(other.iv)) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = ciphertext.contentHashCode()
+        result = 31 * result + iv.contentHashCode()
+        return result
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/core/crypto/EncryptionResult.kt
@@ -18,4 +18,8 @@ data class EncryptionResult(
         result = 31 * result + iv.contentHashCode()
         return result
     }
+
+    override fun toString(): String {
+        return "EncryptionResult(ciphertext=${ciphertext.contentToString()} bytes, iv=${iv.contentToString()} bytes)"
+    }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/IdSerializer.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/IdSerializer.kt
@@ -9,7 +9,7 @@ import com.imeanttobe.consensusapp.Id
 import java.io.InputStream
 import java.io.OutputStream
 
-const val FILE_NAME = "id.pb"
+const val FILE_NAME_ID = "id.pb"
 
 object IdSerializer : Serializer<Id> {
     override val defaultValue: Id
@@ -29,6 +29,6 @@ object IdSerializer : Serializer<Id> {
 }
 
 val Context.idDataStore: DataStore<Id> by dataStore(
-    fileName = FILE_NAME,
+    fileName = FILE_NAME_ID,
     serializer = IdSerializer
 )

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/PollKeyBundlesSerializer.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/PollKeyBundlesSerializer.kt
@@ -1,10 +1,10 @@
 package com.imeanttobe.consensusapp.data.local.serializer
+
 import android.content.Context
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.Serializer
 import androidx.datastore.dataStore
-import com.imeanttobe.consensusapp.Id
 import com.imeanttobe.consensusapp.PollKeyBundles
 import java.io.InputStream
 import java.io.OutputStream

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/PollKeyBundlesSerializer.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/local/serializer/PollKeyBundlesSerializer.kt
@@ -1,0 +1,34 @@
+package com.imeanttobe.consensusapp.data.local.serializer
+import android.content.Context
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import com.imeanttobe.consensusapp.Id
+import com.imeanttobe.consensusapp.PollKeyBundles
+import java.io.InputStream
+import java.io.OutputStream
+
+const val FILE_NAME_KEY_BUNDLE = "poll_key_bundle.pb"
+
+object PollKeyBundlesSerializer : Serializer<PollKeyBundles> {
+    override val defaultValue: PollKeyBundles
+        get() = PollKeyBundles.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): PollKeyBundles {
+        try {
+            return PollKeyBundles.parseFrom(input)
+        } catch (exception: Exception) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    override suspend fun writeTo(t: PollKeyBundles, output: OutputStream) {
+        t.writeTo(output)
+    }
+}
+
+val Context.pollKeyBundlesDataStore: DataStore<PollKeyBundles> by dataStore(
+    fileName = FILE_NAME_KEY_BUNDLE,
+    serializer = PollKeyBundlesSerializer
+)

--- a/app/src/main/proto/poll_key_bundle.proto
+++ b/app/src/main/proto/poll_key_bundle.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package com.imeanttobe.consensusapp;
+
+option java_package = "com.imeanttobe.consensusapp";
+option java_multiple_files = true;
+
+message PollKeyBundle {
+  int32 id = 1;
+  bytes pk = 2;
+  bytes encrypted_sk = 3;
+  bytes iv = 4;
+}
+
+message PollKeyBundles {
+  repeated PollKeyBundle bundles = 1;
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #46 

# 📝 작업 내용
사용자가 여러 투표를 관리할 수 있으려면, 여러 개의 PK-SK 쌍을 기기에 저장해야 해요. 이를 위해 키 저장을 위한 Protobuf 메시지를 정의했고, SK의 암호화 저장을 위해 `CryptoManager`를 추가했어요.

## 세부 구현 내용
- [x] `CryptoManager` 추가 (갈루아/카운터 모드, AES, 키 사이즈 256 비트)
- [x] 키 번들 저장을 위한 Protobuf 메시지 구현
- [x] Protubuf 메시지 추가에 따른 직렬화 도구(serializer) 추가 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앱 내 AES‑GCM 기반 암호화/복호화 기능 추가(공개적인 암호화 API 포함)
  * 폴 키 번들용 프로토콜 버퍼 정의 및 해당 DataStore 직렬화기 추가
  * 암호화 결과를 표현하는 결과 타입 추가(암호문과 IV 포함)

* **개선 사항**
  * 데이터 저장소 파일명 상수명 정리(심볼명 변경)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->