### PR TITLE
[FEAT] SEAL BFV 덧셈 함수 구현

### DIFF
--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -259,32 +259,31 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(
         return nullptr;
     }
 
+    auto deserialize_ciphertext = [&](jbyteArray cipherBytes, Ciphertext& ct) {
+		// JNI ByteArray -> Ciphertext 역직렬화
+		jsize len = env->GetArrayLength(cipherBytes);
+		jbyte* ptr = env->GetByteArrayElements(cipherBytes, nullptr);
+		string serialized_data(reinterpret_cast<char*>(ptr), len);
+		env->ReleaseByteArrayElements(cipherBytes, ptr, JNI_ABORT);
+
+		// 결과 Ciphertext에 로드
+		stringstream stream(serialized_data);
+		ct.load(*g_context, stream);
+        };
+
     try {
-        // --- 1. JNI ByteArray -> Ciphertext 역직렬화 (첫 번째) ---
-        jsize len1 = env->GetArrayLength(cipherBytes1);
-        jbyte* ptr1 = env->GetByteArrayElements(cipherBytes1, nullptr);
-        string serialized_data1(reinterpret_cast<char*>(ptr1), len1);
-        env->ReleaseByteArrayElements(cipherBytes1, ptr1, JNI_ABORT);
-
-        stringstream stream1(serialized_data1);
+        // --- 1. JNI ByteArray -> Ciphertext 역직렬화 
         Ciphertext encrypted1;
-        encrypted1.load(*g_context, stream1);
+		deserialize_ciphertext(cipherBytes1, encrypted1);
 
-        // --- 2. JNI ByteArray -> Ciphertext 역직렬화 (두 번째) ---
-        jsize len2 = env->GetArrayLength(cipherBytes2);
-        jbyte* ptr2 = env->GetByteArrayElements(cipherBytes2, nullptr);
-        string serialized_data2(reinterpret_cast<char*>(ptr2), len2);
-        env->ReleaseByteArrayElements(cipherBytes2, ptr2, JNI_ABORT);
-
-        stringstream stream2(serialized_data2);
         Ciphertext encrypted2;
-        encrypted2.load(*g_context, stream2);
+		deserialize_ciphertext(cipherBytes2, encrypted2);
 
-        // --- 3. 덧셈 연산 (Ciphertext + Ciphertext) ---
+        // --- 2. 덧셈 연산 (Ciphertext + Ciphertext) ---
         Ciphertext encrypted_result;
         g_evaluator->add(encrypted1, encrypted2, encrypted_result);
 
-        // --- 4. 직렬화 (Ciphertext -> Byte Array) ---
+        // --- 3. 직렬화 (Ciphertext -> Byte Array) ---
         stringstream result_stream;
         encrypted_result.save(result_stream);
         string serialized_result = result_stream.str();

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -246,3 +246,59 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_decrypt(
         return nullptr;
     }
 }
+
+// - Ciphertext addition function
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(
+    JNIEnv* env,
+    jobject,
+    jbyteArray cipherBytes1,
+    jbyteArray cipherBytes2) {
+    // Check whether context is initialized
+    if (!g_context || !g_evaluator) {
+        return nullptr;
+    }
+
+    try {
+        // --- 1. JNI ByteArray -> Ciphertext 역직렬화 (첫 번째) ---
+        jsize len1 = env->GetArrayLength(cipherBytes1);
+        jbyte* ptr1 = env->GetByteArrayElements(cipherBytes1, nullptr);
+        string serialized_data1(reinterpret_cast<char*>(ptr1), len1);
+        env->ReleaseByteArrayElements(cipherBytes1, ptr1, JNI_ABORT);
+
+        stringstream stream1(serialized_data1);
+        Ciphertext encrypted1;
+        encrypted1.load(*g_context, stream1);
+
+        // --- 2. JNI ByteArray -> Ciphertext 역직렬화 (두 번째) ---
+        jsize len2 = env->GetArrayLength(cipherBytes2);
+        jbyte* ptr2 = env->GetByteArrayElements(cipherBytes2, nullptr);
+        string serialized_data2(reinterpret_cast<char*>(ptr2), len2);
+        env->ReleaseByteArrayElements(cipherBytes2, ptr2, JNI_ABORT);
+
+        stringstream stream2(serialized_data2);
+        Ciphertext encrypted2;
+        encrypted2.load(*g_context, stream2);
+
+        // --- 3. 덧셈 연산 (Ciphertext + Ciphertext) ---
+        Ciphertext encrypted_result;
+        g_evaluator->add(encrypted1, encrypted2, encrypted_result);
+
+        // --- 4. 직렬화 (Ciphertext -> Byte Array) ---
+        stringstream result_stream;
+        encrypted_result.save(result_stream);
+        string serialized_result = result_stream.str();
+
+        jsize output_len = static_cast<jsize>(serialized_result.size());
+        jbyteArray result = env->NewByteArray(output_len);
+        env->SetByteArrayRegion(result, 0, output_len, reinterpret_cast<const jbyte*>(serialized_result.c_str()));
+
+        return result;
+    } catch (const exception& e) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Error in addCiphertexts: %s", e.what());
+        return nullptr;
+    } catch (...) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Unknown error in addCiphertexts");
+        return nullptr;
+    }
+}

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -151,6 +151,12 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(
         return nullptr;
     }
 
+	// Check whether input array is valid
+	if (inputVector == nullptr) {
+		__android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input vector is null.");
+		return nullptr;
+	}
+
     try {
         // --- 1. JNI jlongArray -> C++ vector<int64_t> 변환 ---
         jsize len = env->GetArrayLength(inputVector);
@@ -204,6 +210,12 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_decrypt(
     if (!g_context || !g_encoder || !g_decryptor) {
         return nullptr;
     }
+
+	// Check whether input byte array is valid
+	if (cipherBytes == nullptr) {
+		__android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input ciphertext byte array is null.");
+		return nullptr;
+	}
 
     try {
         // --- 1. JNI ByteArray -> Ciphertext 역직렬화 ---
@@ -259,6 +271,12 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(
         return nullptr;
     }
 
+	// Check whether input byte arrays are valid
+	if (cipherBytes1 == nullptr || cipherBytes2 == nullptr) {
+		__android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input ciphertext byte arrays are null.");
+		return nullptr;
+	}
+
     auto deserialize_ciphertext = [&](jbyteArray cipherBytes, Ciphertext& ct) {
 		// JNI ByteArray -> Ciphertext 역직렬화
 		jsize len = env->GetArrayLength(cipherBytes);
@@ -277,7 +295,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(
 		deserialize_ciphertext(cipherBytes1, encrypted1);
 
         Ciphertext encrypted2;
-		deserialize_ciphertext(cipherBytes2, encrypted2);
+        deserialize_ciphertext(cipherBytes2, encrypted2);
 
         // --- 2. 덧셈 연산 (Ciphertext + Ciphertext) ---
         Ciphertext encrypted_result;

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -23,8 +23,6 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(JNIEnv *env, jobject, jl
 extern "C" JNIEXPORT jlongArray JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_decrypt(JNIEnv *env, jobject, jbyteArray cipherBytes);
 
-/*
-// Load given PK on native side
-extern "C" JNIEXPORT void JNICALL
-Java_com_imeanttobe_consensusapp_seal_NativeLib_loadPublicKey(JNIEnv *env, jobject, jbyteArray pkBytes);
-*/
+// Adds two ciphertexts.
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(JNIEnv* env, jobject, jbyteArray cipherBytes1, jbyteArray cipherBytes2);

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -10,4 +10,5 @@ object NativeLib {
     external fun generateKeys(): SealKeys?
     external fun encrypt(inputVector: LongArray): ByteArray?
     external fun decrypt(cipherBytes: ByteArray): LongArray?
+    external fun addCiphertexts(cipherBytes1: ByteArray, cipherBytes2: ByteArray): ByteArray?
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -5,10 +5,43 @@ object NativeLib {
         System.loadLibrary("consensus_native")
     }
 
+    /**
+     * 연결 테스트용 함수.
+     * @return 연결 테스트를 위한 문자열
+     */
     external fun stringFromJNI(): String
+
+    /**
+     * SEAL 컨텍스트를 초기화합니다.
+     * @return 초기화 성공 여부 (Boolean)
+     */
     external fun initContext(): Boolean
+
+    /**
+     * 키를 생성합니다.
+     * @return SealKeys 객체 (PK, SK)
+     */
     external fun generateKeys(): SealKeys?
+
+    /**
+     * 평문을 암호문으로 암호화합니다.
+     * @param inputVector 평문 (LongArray)
+     * @return 암호문 (ByteArray?)
+     */
     external fun encrypt(inputVector: LongArray): ByteArray?
+
+    /**
+     * 암호문을 평문으로 복호화합니다.
+     * @param cipherBytes 암호문 (Base64 디코딩된 바이트 배열)
+     * @return 복호화된 평문 (LongArray?)
+     */
     external fun decrypt(cipherBytes: ByteArray): LongArray?
+
+    /**
+     * 두 개의 암호문을 동형암호 덧셈합니다.
+     * @param cipherBytes1 첫 번째 암호문 (Base64 디코딩된 바이트 배열)
+     * @param cipherBytes2 두 번째 암호문
+     * @return 합산된 암호문 (ByteArray?)
+     */
     external fun addCiphertexts(cipherBytes1: ByteArray, cipherBytes2: ByteArray): ByteArray?
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -32,14 +32,14 @@ object NativeLib {
 
     /**
      * 암호문을 평문으로 복호화합니다.
-     * @param cipherBytes 암호문 (Base64 디코딩된 바이트 배열)
+     * @param cipherBytes 암호문
      * @return 복호화된 평문 (LongArray?)
      */
     external fun decrypt(cipherBytes: ByteArray): LongArray?
 
     /**
      * 두 개의 암호문을 동형암호 덧셈합니다.
-     * @param cipherBytes1 첫 번째 암호문 (Base64 디코딩된 바이트 배열)
+     * @param cipherBytes1 첫 번째 암호문
      * @param cipherBytes2 두 번째 암호문
      * @return 합산된 암호문 (ByteArray?)
      */


### PR DESCRIPTION
# 🚩 연관 이슈

closed #35 
closed #34 

# 📝 작업 내용
SEAL의 BFV 스킴 암호문 + 암호문 덧셈 연산을 구현했어요. 추가로, C++ 함수들에 Javadoc 주석도 추가했어요.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데이터 암호화 및 복호화 기능 추가
  * 암호화된 메시지 결합 기능 지원
  * 암호화 키 생성 기능 추가
  * 암호화 시스템 초기화 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->