### PR TITLE
[FEAT] 투표 화면 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml
+/.idea/markdown.xml
 /.idea/assetWizardSettings.xml
 /.idea/deviceManager.xml
 /.idea/androidTestResultsUserPreferences.xml

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -17,7 +17,6 @@ using namespace seal;
 // Unique pointers
 static unique_ptr<SEALContext>  g_context;
 static unique_ptr<KeyGenerator> g_keygen;
-static unique_ptr<Encryptor>    g_encryptor;
 static unique_ptr<Decryptor>    g_decryptor;
 static unique_ptr<Evaluator>    g_evaluator;
 static unique_ptr<BatchEncoder> g_encoder;
@@ -92,7 +91,6 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
         g_keygen->create_public_key(*g_public_key);
 
         // Create encryptor and decryptor
-        g_encryptor = make_unique<Encryptor>(*g_context, *g_public_key);
         g_decryptor = make_unique<Decryptor>(*g_context, *g_secret_key);
 
         // Serialize pk

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -145,19 +145,37 @@ extern "C" JNIEXPORT jbyteArray JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(
         JNIEnv *env,
         jobject,
-        jlongArray inputVector) {
+        jlongArray inputVector,
+	    jbyteArray publicKeyBytes
+) {
     // Check whether context is initialized
-    if (!g_context || !g_encoder || !g_encryptor) {
+    if (!g_context || !g_encoder) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Context is not ready.");
         return nullptr;
     }
 
 	// Check whether input array is valid
-	if (inputVector == nullptr) {
-		__android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input vector is null.");
+	if (inputVector == nullptr || publicKeyBytes == nullptr) {
+		__android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input vector or public key is null.");
 		return nullptr;
 	}
 
     try {
+        // --- 2. 공개 키 로드 (ByteArray -> PublicKey) ---
+        // 전달받은 바이트 배열을 C++ 스트림으로 변환
+        jsize pk_len = env->GetArrayLength(publicKeyBytes);
+        jbyte* pk_ptr = env->GetByteArrayElements(publicKeyBytes, nullptr);
+        string pk_str(reinterpret_cast<char*>(pk_ptr), pk_len);
+        env->ReleaseByteArrayElements(publicKeyBytes, pk_ptr, JNI_ABORT);
+
+        stringstream pk_stream(pk_str);
+        PublicKey public_key;
+        public_key.load(*g_context, pk_stream); // 공개 키 복원
+
+        // --- 3. 일회용 Encryptor 생성 ---
+        // 전역 변수(g_encryptor)를 쓰지 않고, 이 투표만을 위한 암호화기를 만듭니다.
+        Encryptor local_encryptor(*g_context, public_key);
+
         // --- 1. JNI jlongArray -> C++ vector<int64_t> 변환 ---
         jsize len = env->GetArrayLength(inputVector);
         jlong* ptr = env->GetLongArrayElements(inputVector, 0);
@@ -179,7 +197,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(
 
         // --- 3. 암호화 (Plaintext -> Ciphertext) ---
         Ciphertext encrypted;
-        g_encryptor->encrypt(plain, encrypted);
+        local_encryptor.encrypt(plain, encrypted);
 
         // --- 4. 직렬화 (Ciphertext -> Byte Array) ---
         stringstream stream;

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -17,7 +17,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
 
 // Encrypts a vector of integers.
 extern "C" JNIEXPORT jbyteArray JNICALL
-Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(JNIEnv *env, jobject, jlongArray inputVector);
+Java_com_imeanttobe_consensusapp_seal_NativeLib_encrypt(JNIEnv *env, jobject, jlongArray inputVector, jbyteArray publicKeyBytes);
 
 // Decrypts a vector of integers.
 extern "C" JNIEXPORT jlongArray JNICALL

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResponse.kt
@@ -1,6 +1,9 @@
 package com.imeanttobe.consensusapp.data.remote.dto
 
+import android.util.Base64
+import android.util.Log
 import com.google.gson.annotations.SerializedName
+import com.imeanttobe.consensusapp.seal.NativeLib
 
 /**
  * Response type for getting a poll data.
@@ -24,11 +27,20 @@ data class GetPollResponse(
 ) {
     companion object {
         fun getFakeData(): GetPollResponse {
+            val pk = NativeLib.generateKeys()?.pk
+            val encodedPk =
+                if (pk != null) {
+                    Base64.encodeToString(pk, Base64.NO_WRAP)
+                } else {
+                    Log.e("SEAL", "PK is null")
+                    ""
+                }
+
             return GetPollResponse(
                 title = "Title",
                 id = 1,
-                candidates = listOf("Candidate 1", "Candidate 2"),
-                pk = "pk"
+                candidates = listOf("Candidate 1", "Candidate 2", "Candidate 3"),
+                pk = encodedPk
             )
         }
     }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
@@ -27,7 +27,7 @@ data class GetPollResultResponse(
             return GetPollResultResponse(
                 title = "Title",
                 id = 1,
-                candidates = listOf("Candidate 1", "Candidate 2"),
+                candidates = listOf("Candidate 1", "Candidate 2", "Candidate 3"),
                 votes = listOf(1, 2)
             )
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollResultResponse.kt
@@ -28,7 +28,7 @@ data class GetPollResultResponse(
                 title = "Title",
                 id = 1,
                 candidates = listOf("Candidate 1", "Candidate 2", "Candidate 3"),
-                votes = listOf(1, 2)
+                votes = listOf(1, 2, 3)
             )
         }
     }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
@@ -4,6 +4,7 @@ import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import kotlinx.coroutines.delay
 
 class FakePollRepoImpl : PollRepo {
     override suspend fun createPoll(
@@ -22,6 +23,7 @@ class FakePollRepoImpl : PollRepo {
         vote: String,
         code: String
     ): Result<Unit> {
+        delay(500)
         return Result.success(Unit)
     }
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/di/NetworkModule.kt
@@ -4,6 +4,9 @@ import com.imeanttobe.consensusapp.BuildConfig
 import com.imeanttobe.consensusapp.data.remote.api.PollApi
 import com.imeanttobe.consensusapp.data.remote.interceptor.AuthInterceptor
 import com.imeanttobe.consensusapp.data.remote.interceptor.LoggingInterceptor
+import com.imeanttobe.consensusapp.data.repo.FakePollRepoImpl
+import com.imeanttobe.consensusapp.data.repo.PollRepoImpl
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -50,5 +53,15 @@ object NetworkModule {
     @Singleton
     fun providePollApi(retrofit: Retrofit): PollApi {
         return retrofit.create(PollApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun providePollRepo(pollApi: PollApi): PollRepo {
+        return if (BuildConfig.IS_MOCK_ENABLED) {
+            FakePollRepoImpl()
+        } else {
+            PollRepoImpl(pollApi)
+        }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
@@ -16,6 +16,9 @@ sealed interface Route {
     data object DevRoute : Route
 
     @Serializable
+    data class VoteResultScreen(val isVoteSuccess: Boolean, val errorMessage: String) : Route
+
+    @Serializable
     data class HostDashboardScreen(val id: Int) : Route
 
     @Serializable

--- a/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
@@ -16,7 +16,7 @@ sealed interface Route {
     data object DevRoute : Route
 
     @Serializable
-    data class VoteResultScreen(val isVoteSuccess: Boolean, val errorMessage: String) : Route
+    data class VoteResultScreen(val isVoteSuccess: Boolean, val errorMessage: String? = null) : Route
 
     @Serializable
     data class HostDashboardScreen(val id: Int) : Route

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -28,7 +28,7 @@ object NativeLib {
      * @param inputVector 평문 (LongArray)
      * @return 암호문 (ByteArray?)
      */
-    external fun encrypt(inputVector: LongArray): ByteArray?
+    external fun encrypt(inputVector: LongArray, publicKeyBytes: ByteArray): ByteArray?
 
     /**
      * 암호문을 평문으로 복호화합니다.

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -26,6 +26,7 @@ object NativeLib {
     /**
      * 평문을 암호문으로 암호화합니다.
      * @param inputVector 평문 (LongArray)
+     * @param publicKeyBytes 공개 키
      * @return 암호문 (ByteArray?)
      */
     external fun encrypt(inputVector: LongArray, publicKeyBytes: ByteArray): ByteArray?

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -15,6 +15,7 @@ import com.imeanttobe.consensusapp.ui.host_dashboard.HostDashboardScreen
 import com.imeanttobe.consensusapp.ui.result.ResultScreen
 import com.imeanttobe.consensusapp.ui.splash.SplashScreen
 import com.imeanttobe.consensusapp.ui.vote.VoteScreen
+import com.imeanttobe.consensusapp.ui.vote_result.VoteResultScreen
 import com.imeanttobe.consensusapp.ui.waiting.WaitingScreen
 
 @Composable
@@ -52,12 +53,17 @@ fun ConsensusNavGraph() {
                 ),
         ) { backStackEntry ->
             val route: Route.VoteScreen = backStackEntry.toRoute()
-            VoteScreen(id = route.id)
+            VoteScreen(id = route.id, navController = navController)
         }
 
         composable<Route.ResultScreen> { backStackEntry ->
             val route: Route.ResultScreen = backStackEntry.toRoute()
             ResultScreen(id = route.id)
+        }
+
+        composable<Route.VoteResultScreen> { backStackEntry ->
+            val route: Route.VoteResultScreen = backStackEntry.toRoute()
+            VoteResultScreen(isVoteSuccess = route.isVoteSuccess, errorMessage = route.errorMessage)
         }
 
         composable<Route.HostDashboardScreen> { backStackEntry ->

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/common/InputItemDescription.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/common/InputItemDescription.kt
@@ -1,4 +1,4 @@
-package com.imeanttobe.consensusapp.ui.create_poll.components
+package com.imeanttobe.consensusapp.ui.common
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -39,7 +39,7 @@ import com.imeanttobe.consensusapp.core.Constants.MIN_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.ui.create_poll.components.AddOptionDialog
 import com.imeanttobe.consensusapp.ui.create_poll.components.CreatePollScreenTopBar
-import com.imeanttobe.consensusapp.ui.create_poll.components.InputItemDescription
+import com.imeanttobe.consensusapp.ui.common.InputItemDescription
 import com.imeanttobe.consensusapp.ui.create_poll.components.OptionChip
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/splash/SplashViewModel.kt
@@ -1,5 +1,6 @@
 package com.imeanttobe.consensusapp.ui.splash
 
+import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -53,7 +54,7 @@ class SplashViewModel @Inject constructor(
                     return@launch
                 }
 
-                delay(1000)
+                delay(800)
                 
                 // 2. Prepare id
                 _loadingMessage.value = "기기 정보를 확인하는 중..."
@@ -61,7 +62,7 @@ class SplashViewModel @Inject constructor(
                     processIdCheck()
                 }
 
-                delay(1000)
+                delay(800)
 
                 if (idResult.isSuccess) {
                     _splashState.value = UiState.Success(Unit)

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -88,9 +88,9 @@ fun VoteScreen(
     }
 
     Scaffold(modifier = modifier) { innerPadding ->
-        when (pollResponseUiState.value) {
+        when (val pollState = pollResponseUiState.value) {
             is UiState.Success -> {
-                val response = (pollResponseUiState.value as UiState.Success<GetPollResponse>).data
+                val response = pollState.data
 
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -32,7 +32,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.imeanttobe.consensusapp.core.UiState
-import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.navigation.Route
 import com.imeanttobe.consensusapp.ui.common.InputItemDescription
 import com.imeanttobe.consensusapp.ui.vote.components.CandidateCard
@@ -73,7 +72,7 @@ fun VoteScreen(
                         isVoteSuccess = true,
                         errorMessage = ""
                     )
-                ) { popUpTo(Route.VoteResultScreen) { inclusive = true } }
+                ) { launchSingleTop = true }
             }
             is UiState.Failure -> {
                 navController.navigate(
@@ -81,7 +80,7 @@ fun VoteScreen(
                         isVoteSuccess = false,
                         errorMessage = (voteRequestUiState.value as UiState.Failure).message
                     )
-                ) { popUpTo(Route.VoteResultScreen) { inclusive = true } }
+                ) { launchSingleTop = true }
             }
             else -> {}
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -1,17 +1,236 @@
 package com.imeanttobe.consensusapp.ui.vote
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.HowToVote
+import androidx.compose.material.icons.outlined.Password
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
+import com.imeanttobe.consensusapp.navigation.Route
+import com.imeanttobe.consensusapp.ui.common.InputItemDescription
+import com.imeanttobe.consensusapp.ui.vote.components.CandidateCard
+import com.imeanttobe.consensusapp.ui.vote.components.VoteConfirmDialog
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun VoteScreen(id: Int) {
-    Scaffold { innerPadding ->
-        Text(
-            text = "Vote Screen: $id",
-            modifier = Modifier.padding(innerPadding),
+fun VoteScreen(
+    id: Int,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    viewModel: VoteViewModel = hiltViewModel()
+) {
+    val voteCode = viewModel.voteCode.collectAsStateWithLifecycle()
+    val pollResponseUiState = viewModel.pollResponseUiState.collectAsStateWithLifecycle()
+    val voteRequestUiState = viewModel.voteRequestUiState.collectAsStateWithLifecycle()
+    val selectedCandidate = viewModel.selectedCandidate.collectAsStateWithLifecycle()
+    val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
+    val voteStatusMessage = viewModel.voteStatusMessage.collectAsStateWithLifecycle()
+
+    val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
+    val handleDismiss: () -> Unit = { viewModel.setDialogState(false) }
+    val handleVote: () -> Unit = {
+        viewModel.setDialogState(false)
+        viewModel.vote()
+    }
+
+    val isSubmitButtonEnabled = voteCode.value.isNotEmpty()
+            && selectedCandidate.value.isNotBlank()
+            && pollResponseUiState.value is UiState.Success
+            && voteRequestUiState.value !is UiState.Loading
+
+    LaunchedEffect(key1 = voteRequestUiState.value) {
+        when (voteRequestUiState.value) {
+            is UiState.Success -> {
+                navController.navigate(
+                    Route.VoteResultScreen(
+                        isVoteSuccess = true,
+                        errorMessage = ""
+                    )
+                )
+            }
+            is UiState.Failure -> {
+                navController.navigate(
+                    Route.VoteResultScreen(
+                        isVoteSuccess = false,
+                        errorMessage = (voteRequestUiState.value as UiState.Failure).message
+                    )
+                )
+            }
+            else -> {}
+        }
+    }
+
+    Scaffold(modifier = modifier) { innerPadding ->
+        when (pollResponseUiState.value) {
+            is UiState.Success -> {
+                val response = (pollResponseUiState.value as UiState.Success<GetPollResponse>).data
+
+                Box(
+                    modifier = Modifier
+                        .padding(paddingValues = innerPadding)
+                        .fillMaxSize()
+                ) {
+                    // Main content
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp)
+                    ) {
+                        ElevatedCard(
+                            colors = CardDefaults.elevatedCardColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary
+                            ),
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)
+                        ) {
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.fillMaxWidth().padding(16.dp)
+                            ) {
+                                Text(
+                                    text = response.title,
+                                    style = MaterialTheme.typography.headlineMedium
+                                )
+                                Text(
+                                    text = "#$id",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
+
+                        InputItemDescription(
+                            title = "투표 코드",
+                            icon = Icons.Outlined.Password,
+                            description = "투표 주최자에게 제공받은 투표 코드를 입력하세요.",
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        OutlinedTextField(
+                            value = voteCode.value,
+                            onValueChange = viewModel::setVoteCode,
+                            label = { Text(text = "투표 코드") },
+                            singleLine = true,
+                            maxLines = 1,
+                            placeholder = { Text(text = "ABCD1234")},
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)
+                        )
+
+                        InputItemDescription(
+                            title = "선택",
+                            icon = Icons.Outlined.HowToVote,
+                            description = "투표하고 싶은 후보를 1개 골라주세요.",
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            response.candidates.forEach { candidate ->
+                                CandidateCard(
+                                    candidate = candidate,
+                                    isSelected = selectedCandidate.value == candidate,
+                                    onClick = { viewModel.setSelectedCandidate(candidate) }
+                                )
+                            }
+                        }
+                    }
+
+                    // Submit button
+                    Button(
+                        onClick = handleOpenDialog,
+                        enabled = isSubmitButtonEnabled,
+                        contentPadding = ButtonDefaults.MediumContentPadding,
+                        modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
+                    ) {
+                        if (voteRequestUiState.value is UiState.Loading) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                CircularWavyProgressIndicator(modifier = Modifier.size(ButtonDefaults.MediumIconSize))
+                                Text(
+                                    text = voteStatusMessage.value,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        } else {
+                            Text(text = "투표하기")
+                        }
+                    }
+                }
+            }
+            is UiState.Failure -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(paddingValues = innerPadding)
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ErrorOutline,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp).padding(bottom = 16.dp)
+                    )
+                    Text(
+                        text = "투표 데이터를 불러오지 못했어요: ${(pollResponseUiState.value as UiState.Failure).message}",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+            else -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(paddingValues = innerPadding)
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
+                    CircularWavyProgressIndicator(modifier = Modifier.padding(bottom = 16.dp))
+                    Text(
+                        text = "투표 데이터를 불러오는 중...",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+
+    if (dialogState.value) {
+        VoteConfirmDialog(
+            onConfirm = handleVote,
+            onDismiss = handleDismiss
         )
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -59,7 +59,7 @@ fun VoteScreen(
         viewModel.vote()
     }
 
-    val isSubmitButtonEnabled = voteCode.value.isNotEmpty()
+    val isSubmitButtonEnabled = voteCode.value.isNotBlank()
             && selectedCandidate.value.isNotBlank()
             && pollResponseUiState.value is UiState.Success
             && voteRequestUiState.value !is UiState.Loading
@@ -206,7 +206,7 @@ fun VoteScreen(
                         modifier = Modifier.size(64.dp).padding(bottom = 16.dp)
                     )
                     Text(
-                        text = "투표 데이터를 불러오지 못했어요: ${(pollResponseUiState.value as UiState.Failure).message}",
+                        text = "투표 데이터를 불러오지 못했어요: ${pollState.message}",
                         color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.bodyMedium,
                     )

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -73,7 +73,7 @@ fun VoteScreen(
                         isVoteSuccess = true,
                         errorMessage = ""
                     )
-                )
+                ) { popUpTo(Route.VoteResultScreen) { inclusive = true } }
             }
             is UiState.Failure -> {
                 navController.navigate(
@@ -81,7 +81,7 @@ fun VoteScreen(
                         isVoteSuccess = false,
                         errorMessage = (voteRequestUiState.value as UiState.Failure).message
                     )
-                )
+                ) { popUpTo(Route.VoteResultScreen) { inclusive = true } }
             }
             else -> {}
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteScreen.kt
@@ -72,7 +72,10 @@ fun VoteScreen(
                         isVoteSuccess = true,
                         errorMessage = ""
                     )
-                ) { launchSingleTop = true }
+                ) {
+                    popUpTo(Route.VoteScreen) { inclusive = true }
+                    launchSingleTop = true
+                }
             }
             is UiState.Failure -> {
                 navController.navigate(
@@ -80,7 +83,10 @@ fun VoteScreen(
                         isVoteSuccess = false,
                         errorMessage = (voteRequestUiState.value as UiState.Failure).message
                     )
-                ) { launchSingleTop = true }
+                ) {
+                    popUpTo(Route.VoteScreen) { inclusive = true }
+                    launchSingleTop = true
+                }
             }
             else -> {}
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
@@ -81,9 +81,15 @@ class VoteViewModel @Inject constructor(
 
             // Encrypt vector and encode with base64
             _voteStatusMessage.value = "투표 값 암호화 중..."
-            val pk = Base64.decode(poll.pk, Base64.NO_WRAP)
-            val ciphertext = withContext(Dispatchers.IO) {
-                NativeLib.encrypt(plaintext, pk)
+            val ciphertext = try {
+                val pk = Base64.decode(poll.pk, Base64.NO_WRAP)
+                withContext(Dispatchers.IO) {
+                    NativeLib.encrypt(plaintext, pk)
+                }
+            } catch (e: Exception) {
+                Log.e("VoteViewModel", "Encryption failed", e)
+                _voteRequestUiState.value = UiState.Failure("Encryption failed")
+                return@launch
             }
             if (ciphertext == null) {
                 _voteRequestUiState.value = UiState.Failure("Encryption failed")

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
@@ -64,12 +64,12 @@ class VoteViewModel @Inject constructor(
 
             // Get data
             _voteStatusMessage.value = "데이터 준비 중..."
-            if (pollResponseUiState.value !is UiState.Success) {
+            val pollState = pollResponseUiState.value
+            if (pollState !is UiState.Success) {
                 _voteRequestUiState.value = UiState.Failure("Poll data is not loaded")
                 return@launch
             }
-            val response = pollResponseUiState.value as UiState.Success<GetPollResponse>
-            val poll = response.data
+            val poll = pollState.data
 
             // Prepare vector
             val plaintext = LongArray(poll.candidates.size) { 0 }
@@ -115,8 +115,13 @@ class VoteViewModel @Inject constructor(
                 val response = result.getOrNull()
 
                 if (response != null) {
-                    _pollResponseUiState.value = UiState.Success(response)
-                    _selectedCandidate.value = response.candidates[0]
+                    val firstCandidate = response.candidates.firstOrNull()
+                    if (firstCandidate != null) {
+                        _selectedCandidate.value = firstCandidate
+                        _pollResponseUiState.value = UiState.Success(response)
+                    } else {
+                        _pollResponseUiState.value = UiState.Failure("No candidates found")
+                    }
                 } else {
                     _pollResponseUiState.value = UiState.Failure("Response is null")
                 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
@@ -1,0 +1,128 @@
+package com.imeanttobe.consensusapp.ui.vote
+
+import android.util.Base64
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import com.imeanttobe.consensusapp.seal.NativeLib
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class VoteViewModel @Inject constructor(
+    private val pollRepo: PollRepo,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val _pollResponseUiState = MutableStateFlow<UiState<GetPollResponse>>(UiState.Idle)
+    val pollResponseUiState: StateFlow<UiState<GetPollResponse>> = _pollResponseUiState
+
+    private val _voteRequestUiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
+    val voteRequestUiState: StateFlow<UiState<Unit>> = _voteRequestUiState
+
+    private val _voteCode = MutableStateFlow("")
+    val voteCode: StateFlow<String> = _voteCode
+
+    private val _voteStatusMessage = MutableStateFlow("")
+    val voteStatusMessage: StateFlow<String> = _voteStatusMessage
+
+    private val _dialogState = MutableStateFlow(false)
+    val dialogState: StateFlow<Boolean> = _dialogState
+
+    private val _selectedCandidate = MutableStateFlow("")
+    val selectedCandidate: StateFlow<String> = _selectedCandidate
+
+    init {
+        val id = savedStateHandle.get<Int>("id") ?: -1
+        loadPollData(id)
+    }
+
+    fun setDialogState(state: Boolean) {
+        _dialogState.value = state
+    }
+
+    fun setVoteCode(code: String) {
+        _voteCode.value = code
+    }
+
+    fun setSelectedCandidate(candidate: String) {
+        _selectedCandidate.value = candidate
+    }
+
+    fun vote() {
+        viewModelScope.launch {
+            _voteRequestUiState.value = UiState.Loading
+
+            // Get data
+            _voteStatusMessage.value = "데이터 준비 중..."
+            if (pollResponseUiState.value !is UiState.Success) {
+                _voteRequestUiState.value = UiState.Failure("Poll data is not loaded")
+                return@launch
+            }
+            val response = pollResponseUiState.value as UiState.Success<GetPollResponse>
+            val poll = response.data
+
+            // Prepare vector
+            val plaintext = LongArray(poll.candidates.size) { 0 }
+            poll.candidates.forEachIndexed { index, candidate ->
+                if (candidate == selectedCandidate.value) {
+                    plaintext[index] = 1
+                }
+            }
+            delay(500)
+
+            // Encrypt vector and encode with base64
+            _voteStatusMessage.value = "투표 값 암호화 중..."
+            val pk = Base64.decode(poll.pk, Base64.NO_WRAP)
+            val ciphertext = withContext(Dispatchers.IO) {
+                NativeLib.encrypt(plaintext, pk)
+            }
+            if (ciphertext == null) {
+                _voteRequestUiState.value = UiState.Failure("Encryption failed")
+                return@launch
+            }
+            val encodedCiphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP)
+            delay(500)
+
+            // Send it
+            _voteStatusMessage.value = "투표 값 서버에 전송 중..."
+            val result = pollRepo.vote(id = poll.id, code = voteCode.value, vote = encodedCiphertext)
+            if (result.isSuccess) {
+                _voteRequestUiState.value = UiState.Success(Unit)
+            } else {
+                _voteRequestUiState.value = UiState.Failure(result.exceptionOrNull()?.message ?: "Unknown error")
+            }
+        }
+    }
+
+    private fun loadPollData(id: Int) {
+        viewModelScope.launch {
+            _pollResponseUiState.value = UiState.Loading
+
+            delay(500)
+
+            val result = pollRepo.getPoll(id)
+            if (result.isSuccess) {
+                val response = result.getOrNull()
+
+                if (response != null) {
+                    _pollResponseUiState.value = UiState.Success(response)
+                    _selectedCandidate.value = response.candidates[0]
+                } else {
+                    _pollResponseUiState.value = UiState.Failure("Response is null")
+                }
+            } else {
+                _pollResponseUiState.value = UiState.Failure(result.exceptionOrNull()?.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/VoteViewModel.kt
@@ -78,7 +78,6 @@ class VoteViewModel @Inject constructor(
                     plaintext[index] = 1
                 }
             }
-            delay(500)
 
             // Encrypt vector and encode with base64
             _voteStatusMessage.value = "투표 값 암호화 중..."
@@ -91,7 +90,6 @@ class VoteViewModel @Inject constructor(
                 return@launch
             }
             val encodedCiphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP)
-            delay(500)
 
             // Send it
             _voteStatusMessage.value = "투표 값 서버에 전송 중..."

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/components/CandidateCard.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/components/CandidateCard.kt
@@ -1,0 +1,76 @@
+package com.imeanttobe.consensusapp.ui.vote.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CandidateCard(
+    candidate: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val containerColor =
+        if (isSelected) MaterialTheme.colorScheme.primaryContainer
+        else MaterialTheme.colorScheme.surface
+    val contentColor =
+        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+        else MaterialTheme.colorScheme.onSurface
+    val borderColor =
+        if (isSelected) MaterialTheme.colorScheme.primary
+        else MaterialTheme.colorScheme.outline
+    val borderWidth = if (isSelected) 2.dp else 1.dp
+    val elevation = if (isSelected) 4.dp else 0.dp
+    val alpha = if (isSelected) 1f else 0f
+    val fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+
+    OutlinedCard(
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = containerColor,
+            contentColor = contentColor
+        ),
+        border = BorderStroke(
+            width = borderWidth,
+            color = borderColor
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = elevation
+        )
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 32.dp)
+        ) {
+            Text(
+                text = candidate,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = fontWeight,
+                color = contentColor,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = Icons.Outlined.Check,
+                contentDescription = "Selected",
+                tint = contentColor,
+                modifier = Modifier.alpha(alpha)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/components/VoteConfirmDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote/components/VoteConfirmDialog.kt
@@ -1,0 +1,37 @@
+package com.imeanttobe.consensusapp.ui.vote.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.HowToVote
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun VoteConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.HowToVote,
+                contentDescription = null
+            )
+        },
+        onDismissRequest = onDismiss,
+        title = { Text(text = "최종 확인") },
+        text = { Text(text = "확인을 누르면 선택을 되돌릴 수 없어요. 투표를 완료하시겠어요?") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = "확인")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = "취소")
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote_result/VoteResultScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote_result/VoteResultScreen.kt
@@ -1,0 +1,69 @@
+package com.imeanttobe.consensusapp.ui.vote_result
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.imeanttobe.consensusapp.core.findActivity
+
+@Composable
+fun VoteResultScreen(
+    isVoteSuccess: Boolean,
+    errorMessage: String,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val iconImageVector =
+        if (isVoteSuccess) Icons.Outlined.CheckCircle
+        else Icons.Outlined.ErrorOutline
+    val message =
+        if (isVoteSuccess) "투표에 성공했어요!"
+        else "투표에 실패했어요. 오류 내용: $errorMessage"
+
+    val handleTerminate: () -> Unit = {
+        context.findActivity()?.finish()
+    }
+
+    Scaffold(modifier = modifier) { innerPadding ->
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            Icon(
+                imageVector = iconImageVector,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(64.dp).padding(bottom = 16.dp)
+            )
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+            Button(
+                onClick = handleTerminate,
+                modifier = Modifier.padding(bottom = 16.dp)
+            ) {
+                Text(text = "종료")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/vote_result/VoteResultScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/vote_result/VoteResultScreen.kt
@@ -23,7 +23,7 @@ import com.imeanttobe.consensusapp.core.findActivity
 @Composable
 fun VoteResultScreen(
     isVoteSuccess: Boolean,
-    errorMessage: String,
+    errorMessage: String?,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -32,7 +32,7 @@ fun VoteResultScreen(
         else Icons.Outlined.ErrorOutline
     val message =
         if (isVoteSuccess) "투표에 성공했어요!"
-        else "투표에 실패했어요. 오류 내용: $errorMessage"
+        else "투표에 실패했어요. 오류 내용: ${errorMessage ?: "알 수 없음"}"
 
     val handleTerminate: () -> Unit = {
         context.findActivity()?.finish()
@@ -50,7 +50,9 @@ fun VoteResultScreen(
                 imageVector = iconImageVector,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(64.dp).padding(bottom = 16.dp)
+                modifier = Modifier
+                    .size(64.dp)
+                    .padding(bottom = 16.dp)
             )
             Text(
                 text = message,


### PR DESCRIPTION
# 🚩 연관 이슈

closed #14 

# 📝 작업 내용
투표 화면을 구현했어요. 

## 투표 화면 구현
- [x] 투표 화면에 필요한 부분 UI 구현
- [x] 투표 화면 `VoteScreen` 구현
- [x] 투표 결과 화면 `VoteResultScreen` 구현 및 라우터에 등록

## 그 외
- [x] 테스트를 위해 가짜 응답이 `NativeLib`으로 PK를 생성하도록 수정
- [x] API 모방 활성화 시 `PollRepo`가 가짜 저장소로 대체되도록 수정
- [x] `InputItemDescription`을 공용 컴포넌트 디렉토리로 이동 
- [x] 암호화 함수가 공개 키를 입력으로 받고, 임시 `Encryptor`를 생성하여 암호화하도록 개선 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * MVVM 기반 투표 화면 및 VoteViewModel 도입
  * 후보자 카드(CandidateCard)와 최종 확인 다이얼로그(VoteConfirmDialog) 추가
  * 투표 결과 화면에 오류 메시지 표시 가능(Route/VoteResultScreen)

* **개선사항**
  * 투표 제출 흐름 개선: 클라이언트 측 암호화 방식이 공개키를 사용하도록 갱신
  * 후보자 수 3명으로 확장 및 투표 UI/네비게이션 정비
  * 스플래시 로딩 시간 단축(1000ms→800ms)

* **변경/테스트용**
  * 모의 리포지토리 선택 기능 추가 및 페이크 투표에 500ms 지연 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->