### PR TITLE
[FEAT] 투표 생성 화면에 네트워크 요청 로직 추가

### DIFF
--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.delay
 class FakePollRepoImpl : PollRepo {
     override suspend fun createPoll(
         title: String,
+        pk: String,
         candidates: List<String>
     ): Result<CreatePollResponse> {
         return Result.success(CreatePollResponse.getFakeData())

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -85,10 +85,9 @@ class PollRepoImpl @Inject constructor(
 
     override suspend fun createPoll(
         title: String,
+        pk: String,
         candidates: List<String>
     ): Result<CreatePollResponse> {
-        val pk = "" // TODO: have to generate pk here
-
         return try {
             val request = CreatePollRequest(title, pk, candidates)
             val response = pollApi.createPoll(request)

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
@@ -10,6 +10,5 @@ interface PollRepo {
     suspend fun finishPoll(id: Int): Result<Unit>
     suspend fun getPollResult(id: Int): Result<GetPollResultResponse>
     suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit>
-    // Public key will be given in actual impl
-    suspend fun createPoll(title: String, candidates: List<String>): Result<CreatePollResponse>
+    suspend fun createPoll(title: String, pk: String, candidates: List<String>): Result<CreatePollResponse>
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -46,9 +46,9 @@ import com.imeanttobe.consensusapp.core.Constants.MIN_OPTIONS
 import com.imeanttobe.consensusapp.core.Constants.MIN_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.navigation.Route
+import com.imeanttobe.consensusapp.ui.common.InputItemDescription
 import com.imeanttobe.consensusapp.ui.create_poll.components.AddOptionDialog
 import com.imeanttobe.consensusapp.ui.create_poll.components.CreatePollScreenTopBar
-import com.imeanttobe.consensusapp.ui.common.InputItemDescription
 import com.imeanttobe.consensusapp.ui.create_poll.components.OptionChip
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Edit
@@ -59,6 +62,7 @@ fun CreatePollScreen(
     val title = viewModel.title.collectAsStateWithLifecycle()
     val numParticipants = viewModel.numParticipants.collectAsStateWithLifecycle()
     val options = viewModel.options.collectAsStateWithLifecycle()
+    val statusMessage = viewModel.statusMessage.collectAsStateWithLifecycle()
     val newOption = viewModel.newOption.collectAsStateWithLifecycle()
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
@@ -101,8 +105,8 @@ fun CreatePollScreen(
                     snackbarHostState.showSnackbar(
                         message = "투표 생성 실패. 원인: ${uiStateValue.message}"
                     )
+                    viewModel.resetUiState()
                 }
-                navController.popBackStack()
             }
             else -> {}
         }
@@ -201,9 +205,20 @@ fun CreatePollScreen(
                 modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
             ) {
                 if (uiState.value is UiState.Loading) {
-                    CircularWavyProgressIndicator()
+                    Row(
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        CircularWavyProgressIndicator(modifier = Modifier.size(ButtonDefaults.MediumIconSize))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = statusMessage.value,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
                 } else {
-                    Text(text = "투표 개최하기")
+                    Text(text = "개최하기")
                 }
             }
         }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollScreen.kt
@@ -22,8 +22,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -37,10 +42,12 @@ import com.imeanttobe.consensusapp.core.Constants.MAX_TITLE_LENGTH
 import com.imeanttobe.consensusapp.core.Constants.MIN_OPTIONS
 import com.imeanttobe.consensusapp.core.Constants.MIN_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.navigation.Route
 import com.imeanttobe.consensusapp.ui.create_poll.components.AddOptionDialog
 import com.imeanttobe.consensusapp.ui.create_poll.components.CreatePollScreenTopBar
 import com.imeanttobe.consensusapp.ui.common.InputItemDescription
 import com.imeanttobe.consensusapp.ui.create_poll.components.OptionChip
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -55,10 +62,12 @@ fun CreatePollScreen(
     val newOption = viewModel.newOption.collectAsStateWithLifecycle()
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     val handleBackClick: () -> Unit = { navController.popBackStack() }
     val handleSliderChange: (Float) -> Unit = { sliderValue -> viewModel.setNumParticipants(sliderValue.toInt()) }
-    val handleSubmit: () -> Unit = { viewModel.submit() }
+    val handleSubmit: () -> Unit = { viewModel.createPoll() }
     val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
     val handleDialogConfirm: () -> Unit = {
         viewModel.appendOption(newOption.value)
@@ -79,8 +88,29 @@ fun CreatePollScreen(
         if (title.value.length < MAX_TITLE_LENGTH) MaterialTheme.colorScheme.primary
         else MaterialTheme.colorScheme.error
 
+    LaunchedEffect(key1 = uiState.value) {
+        when (val uiStateValue = uiState.value) {
+            is UiState.Success -> {
+                val pollInfo = uiStateValue.data
+                navController.navigate(Route.HostDashboardScreen(id = pollInfo.id)) {
+                    popUpTo(Route.CreatePollScreen) { inclusive = true }
+                }
+            }
+            is UiState.Failure -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = "투표 생성 실패. 원인: ${uiStateValue.message}"
+                    )
+                }
+                navController.popBackStack()
+            }
+            else -> {}
+        }
+    }
+
     Scaffold(
         topBar = { CreatePollScreenTopBar(onBackClicked = handleBackClick) },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         modifier = modifier
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -42,6 +43,9 @@ class CreatePollViewModel @Inject constructor(
     private val _newOption = MutableStateFlow<String>("")
     val newOption: StateFlow<String> = _newOption
 
+    private val _statusMessage = MutableStateFlow<String>("")
+    val statusMessage: StateFlow<String> = _statusMessage
+
     private val _numParticipants = MutableStateFlow<Int>(MIN_PARTICIPANTS)
     val numParticipants: StateFlow<Int> = _numParticipants
 
@@ -50,6 +54,11 @@ class CreatePollViewModel @Inject constructor(
 
     private val _dialogState = MutableStateFlow<Boolean>(false)
     val dialogState: StateFlow<Boolean> = _dialogState
+
+    fun resetUiState() {
+        _uiState.value = UiState.Idle
+        _statusMessage.value = ""
+    }
 
     fun setDialogState(state: Boolean) {
         _dialogState.value = state
@@ -103,6 +112,7 @@ class CreatePollViewModel @Inject constructor(
 
         viewModelScope.launch {
             // Prepare PK and SK
+            _statusMessage.value = "키 생성 중..."
             val sealKeys = withContext(Dispatchers.IO) {
                 NativeLib.generateKeys()
             }
@@ -112,6 +122,7 @@ class CreatePollViewModel @Inject constructor(
             }
 
             // Create request body
+            _statusMessage.value = "투표 개최 요청 중..."
             val encodedPk = Base64.encodeToString(sealKeys.pk, Base64.NO_WRAP)
 
             // Send request
@@ -123,24 +134,24 @@ class CreatePollViewModel @Inject constructor(
 
             // Handle response
             if (response.isSuccess) {
-                val responseBody = response.getOrNull()
-                if (responseBody == null) {
-                    _uiState.value = UiState.Failure("Response body is null")
-                    return@launch
-                } else {
-                    // Save poll info to local storage
-                    val encryptionResult = cryptoManager.encrypt(sealKeys.sk)
-                    val newPollInfo = PollInfo.newBuilder()
-                        .setTitle(title.value)
-                        .setId(responseBody.id)
-                        .setPk(sealKeys.pk.toByteString())
-                        .setEncryptedSk(encryptionResult.ciphertext.toByteString())
-                        .setIv(encryptionResult.iv.toByteString())
-                        .build()
-                    pollInfoItemsRepo.addPollInfo(newPollInfo)
+                response.fold(
+                    onSuccess = {  responseBody ->
+                        // Save poll info to local storage
+                        val encryptionResult = cryptoManager.encrypt(sealKeys.sk)
+                        val newPollInfo = PollInfo.newBuilder()
+                            .setTitle(title.value)
+                            .setId(responseBody.id)
+                            .setPk(sealKeys.pk.toByteString())
+                            .setEncryptedSk(encryptionResult.ciphertext.toByteString())
+                            .setIv(encryptionResult.iv.toByteString())
+                            .build()
 
-                    _uiState.value = UiState.Success(newPollInfo)
-                }
+                        pollInfoItemsRepo.addPollInfo(newPollInfo).fold(
+                            onSuccess = { _uiState.value = UiState.Success(newPollInfo) },
+                            onFailure = { _uiState.value = UiState.Failure(it.message ?: "투표 정보를 기기에 저장하는 데 실패했습니다.") }
+                        ) },
+                    onFailure = { _uiState.value = UiState.Failure(it.message ?: "Unknown error") }
+                )
             } else {
                 _uiState.value = UiState.Failure(response.exceptionOrNull()?.message ?: "Unknown error")
             }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -1,22 +1,38 @@
 package com.imeanttobe.consensusapp.ui.create_poll
 
+import android.util.Base64
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.protobuf.kotlin.toByteString
+import com.imeanttobe.consensusapp.PollInfo
 import com.imeanttobe.consensusapp.core.Constants.MAX_OPTIONS
 import com.imeanttobe.consensusapp.core.Constants.MAX_OPTION_LENGTH
 import com.imeanttobe.consensusapp.core.Constants.MAX_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.Constants.MAX_TITLE_LENGTH
 import com.imeanttobe.consensusapp.core.Constants.MIN_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.core.crypto.CryptoManager
+import com.imeanttobe.consensusapp.data.remote.dto.CreatePollRequest
+import com.imeanttobe.consensusapp.domain.repo.PollInfoItemsRepo
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import com.imeanttobe.consensusapp.seal.NativeLib
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class CreatePollViewModel @Inject constructor() : ViewModel() {
+class CreatePollViewModel @Inject constructor(
+    private val pollRepo: PollRepo,
+    private val pollInfoItemsRepo: PollInfoItemsRepo,
+    private val cryptoManager: CryptoManager
+) : ViewModel() {
     private val _title = MutableStateFlow<String>("")
     val title: StateFlow<String> = _title
 
@@ -29,8 +45,8 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
     private val _numParticipants = MutableStateFlow<Int>(MIN_PARTICIPANTS)
     val numParticipants: StateFlow<Int> = _numParticipants
 
-    private val _uiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
-    val uiState: StateFlow<UiState<Unit>> = _uiState
+    private val _uiState = MutableStateFlow<UiState<PollInfo>>(UiState.Idle)
+    val uiState: StateFlow<UiState<PollInfo>> = _uiState
 
     private val _dialogState = MutableStateFlow<Boolean>(false)
     val dialogState: StateFlow<Boolean> = _dialogState
@@ -82,7 +98,52 @@ class CreatePollViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    fun submit() {
-        // TODO: Submit poll to server
+    fun createPoll() {
+        _uiState.value = UiState.Loading
+
+        viewModelScope.launch {
+            // Prepare PK and SK
+            val sealKeys = withContext(Dispatchers.IO) {
+                NativeLib.generateKeys()
+            }
+            if (sealKeys == null) {
+                _uiState.value = UiState.Failure("Failed to generate keys")
+                return@launch
+            }
+
+            // Create request body
+            val encodedPk = Base64.encodeToString(sealKeys.pk, Base64.NO_WRAP)
+
+            // Send request
+            val response = pollRepo.createPoll(
+                title = title.value,
+                pk = encodedPk,
+                candidates = options.value.toList()
+            )
+
+            // Handle response
+            if (response.isSuccess) {
+                val responseBody = response.getOrNull()
+                if (responseBody == null) {
+                    _uiState.value = UiState.Failure("Response body is null")
+                    return@launch
+                } else {
+                    // Save poll info to local storage
+                    val encryptionResult = cryptoManager.encrypt(sealKeys.sk)
+                    val newPollInfo = PollInfo.newBuilder()
+                        .setTitle(title.value)
+                        .setId(responseBody.id)
+                        .setPk(sealKeys.pk.toByteString())
+                        .setEncryptedSk(encryptionResult.ciphertext.toByteString())
+                        .setIv(encryptionResult.iv.toByteString())
+                        .build()
+                    pollInfoItemsRepo.addPollInfo(newPollInfo)
+
+                    _uiState.value = UiState.Success(newPollInfo)
+                }
+            } else {
+                _uiState.value = UiState.Failure(response.exceptionOrNull()?.message ?: "Unknown error")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/CreatePollViewModel.kt
@@ -12,7 +12,6 @@ import com.imeanttobe.consensusapp.core.Constants.MAX_TITLE_LENGTH
 import com.imeanttobe.consensusapp.core.Constants.MIN_PARTICIPANTS
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.core.crypto.CryptoManager
-import com.imeanttobe.consensusapp.data.remote.dto.CreatePollRequest
 import com.imeanttobe.consensusapp.domain.repo.PollInfoItemsRepo
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import com.imeanttobe.consensusapp.seal.NativeLib
@@ -20,7 +19,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -133,28 +131,30 @@ class CreatePollViewModel @Inject constructor(
             )
 
             // Handle response
-            if (response.isSuccess) {
-                response.fold(
-                    onSuccess = {  responseBody ->
-                        // Save poll info to local storage
-                        val encryptionResult = cryptoManager.encrypt(sealKeys.sk)
-                        val newPollInfo = PollInfo.newBuilder()
-                            .setTitle(title.value)
-                            .setId(responseBody.id)
-                            .setPk(sealKeys.pk.toByteString())
-                            .setEncryptedSk(encryptionResult.ciphertext.toByteString())
-                            .setIv(encryptionResult.iv.toByteString())
-                            .build()
+            response.fold(
+                onSuccess = {  responseBody ->
+                    // Save poll info to local storage
+                    val encryptionResult = try {
+                        cryptoManager.encrypt(sealKeys.sk)
+                    } catch (e: Exception) {
+                        _uiState.value = UiState.Failure("Failed to encrypt secret key")
+                        return@launch
+                    }
 
-                        pollInfoItemsRepo.addPollInfo(newPollInfo).fold(
-                            onSuccess = { _uiState.value = UiState.Success(newPollInfo) },
-                            onFailure = { _uiState.value = UiState.Failure(it.message ?: "투표 정보를 기기에 저장하는 데 실패했습니다.") }
-                        ) },
-                    onFailure = { _uiState.value = UiState.Failure(it.message ?: "Unknown error") }
-                )
-            } else {
-                _uiState.value = UiState.Failure(response.exceptionOrNull()?.message ?: "Unknown error")
-            }
+                    val newPollInfo = PollInfo.newBuilder()
+                        .setTitle(title.value)
+                        .setId(responseBody.id)
+                        .setPk(sealKeys.pk.toByteString())
+                        .setEncryptedSk(encryptionResult.ciphertext.toByteString())
+                        .setIv(encryptionResult.iv.toByteString())
+                        .build()
+
+                    pollInfoItemsRepo.addPollInfo(newPollInfo).fold(
+                        onSuccess = { _uiState.value = UiState.Success(newPollInfo) },
+                        onFailure = { _uiState.value = UiState.Failure(it.message ?: "투표 정보를 기기에 저장하는 데 실패했습니다.") }
+                    ) },
+                onFailure = { _uiState.value = UiState.Failure(it.message ?: "Unknown error") }
+            )
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/create_poll/components/AddOptionDialog.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.imeanttobe.consensusapp.core.Constants.MAX_OPTION_LENGTH
-import com.imeanttobe.consensusapp.core.Constants.MAX_TITLE_LENGTH
 
 @Composable
 fun AddOptionDialog(


### PR DESCRIPTION
# 🚩 연관 이슈

closed #51 

# 📝 작업 내용
투표 생성 화면에 네트워크 요청 로직을 추가했어요.

# 세부 작업 내용
- [x] 투표 생성 화면에 네트워크 요청 로직 추가
- [x] `PollRepo`의 `createPoll` 함수가 공개 키도 매개변수로 받도록 수정 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 전체 투표 생성 흐름 추가 — 키 생성, 서버 등록, 비밀키 암호화 및 로컬 저장이 통합되어 동작합니다.
  * 상태 메시지와 스낵바를 통한 오류/성공 알림 제공

* **개선 사항**
  * 투표 생성 화면의 로딩 UI 강화(진행 상태 메시지 표시) 및 버튼 레이블 업데이트
  * 생성 성공 시 자동으로 호스트 대시보드로 이동

* **기타**
  * 사소한 코드 정리(불필요한 import 제거)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->