### PR TITLE
[FEAT] 주최자 대시보드 화면 구현

### DIFF
--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/api/PollApi.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/api/PollApi.kt
@@ -5,6 +5,7 @@ import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.FinishPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
 import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultRequest
 import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultResponse
 import com.imeanttobe.consensusapp.data.remote.dto.VoteRequest
@@ -47,4 +48,9 @@ interface PollApi {
     suspend fun getPollResult(
         @Path("id") id: Int
     ): Response<GetPollResultResponse>
+
+    @GET("api/polls/{id}/status")
+    suspend fun getPollStatus(
+        @Path("id") id: Int
+    ): Response<GetPollStatusResponse>
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollStatusResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollStatusResponse.kt
@@ -1,0 +1,39 @@
+package com.imeanttobe.consensusapp.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Response type for getting poll results
+ * @param title Poll title
+ * @param id Poll id
+ * @param candidates Poll candidates
+ * @param votes Decrypted poll votes
+ */
+data class GetPollStatusResponse(
+    @SerializedName("title")
+    val title: String,
+
+    @SerializedName("id")
+    val id: Int,
+
+    @SerializedName("candidates")
+    val candidates: List<String>,
+
+    @SerializedName("codes")
+    val codes: List<String>,
+
+    @SerializedName("usedCodes")
+    val usedCodes: List<String>
+) {
+    companion object {
+        fun getFakeData(): GetPollStatusResponse {
+            return GetPollStatusResponse(
+                title = "Title",
+                id = 1,
+                candidates = listOf("Candidate 1", "Candidate 2", "Candidate 3"),
+                codes = listOf("ABCD1234", "EFGH5678", "IJKL9012"),
+                usedCodes = listOf("ABCD1234", "EFGH5678")
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollStatusResponse.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/remote/dto/GetPollStatusResponse.kt
@@ -7,7 +7,8 @@ import com.google.gson.annotations.SerializedName
  * @param title Poll title
  * @param id Poll id
  * @param candidates Poll candidates
- * @param votes Decrypted poll votes
+ * @param codes Poll codes
+ * @param usedCodes Used poll codes
  */
 data class GetPollStatusResponse(
     @SerializedName("title")

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
@@ -3,6 +3,7 @@ package com.imeanttobe.consensusapp.data.repo
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import kotlinx.coroutines.delay
 
@@ -12,6 +13,10 @@ class FakePollRepoImpl : PollRepo {
         candidates: List<String>
     ): Result<CreatePollResponse> {
         return Result.success(CreatePollResponse.getFakeData())
+    }
+
+    override suspend fun getPollStatus(id: Int): Result<GetPollStatusResponse> {
+        return Result.success(GetPollStatusResponse.getFakeData())
     }
 
     override suspend fun getPoll(id: Int): Result<GetPollResponse> {

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -5,6 +5,7 @@ import com.imeanttobe.consensusapp.data.remote.dto.CreatePollRequest
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
 import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultRequest
 import com.imeanttobe.consensusapp.data.remote.dto.VoteRequest
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
@@ -102,6 +103,26 @@ class PollRepoImpl @Inject constructor(
                     Result.failure(Exception("Response body is null"))
                 }
             } else {
+                Result.failure(Exception(response.message()))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getPollStatus(id: Int): Result<GetPollStatusResponse> {
+        return try {
+            val response = pollApi.getPollStatus(id)
+
+            if (response.isSuccessful) {
+                val body = response.body()
+
+                if (body != null) {
+                    Result.success(body)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
+                } else {
                 Result.failure(Exception(response.message()))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -121,7 +121,7 @@ class PollRepoImpl @Inject constructor(
                 } else {
                     Result.failure(Exception("Response body is null"))
                 }
-                } else {
+            } else {
                 Result.failure(Exception(response.message()))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
@@ -3,6 +3,7 @@ package com.imeanttobe.consensusapp.domain.repo
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
 
 interface PollRepo {
     suspend fun getPoll(id: Int): Result<GetPollResponse>
@@ -12,4 +13,5 @@ interface PollRepo {
     suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit>
     // Public key will be given in actual impl
     suspend fun createPoll(title: String, candidates: List<String>): Result<CreatePollResponse>
+    suspend fun getPollStatus(id: Int): Result<GetPollStatusResponse>
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -68,7 +68,7 @@ fun ConsensusNavGraph() {
 
         composable<Route.HostDashboardScreen> { backStackEntry ->
             val route: Route.HostDashboardScreen = backStackEntry.toRoute()
-            HostDashboardScreen(id = route.id)
+            HostDashboardScreen(id = route.id, navController = navController)
         }
 
         composable<Route.WaitingScreen> { backStackEntry ->

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
@@ -262,7 +262,7 @@ fun HostDashboardScreen(
                         }
 
                         Column(
-                            modifier = Modifier.fillMaxWidth()
+                            modifier = Modifier.fillMaxWidth().weight(1f)
                         ) {
                             Text(
                                 text = "투표 코드 관리",
@@ -326,7 +326,6 @@ fun HostDashboardScreen(
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth()
                             ) {
                                 CircularWavyProgressIndicator(modifier = Modifier.size(ButtonDefaults.MediumIconSize))
                                 Text(

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
@@ -175,7 +175,7 @@ fun HostDashboardScreen(
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(16.dp),
+                            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 80.dp),
                         verticalArrangement = Arrangement.spacedBy(24.dp)
                     ) {
                         // [1] 상단: 투표 정보
@@ -292,7 +292,7 @@ fun HostDashboardScreen(
                                     EmptyStateText("모든 코드가 사용되었습니다! 🎉")
                                 } else {
                                     LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        items(unusedCodes.toList()) { code ->
+                                        items(unusedCodes.toList(), key = { it }) { code ->
                                             UnusedCodeItem(
                                                 code = code,
                                                 onShare = { handleShareCode(it, response.title) }
@@ -306,7 +306,7 @@ fun HostDashboardScreen(
                                     EmptyStateText("아직 투표한 사람이 없습니다.")
                                 } else {
                                     LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        items(usedCodes) { code ->
+                                        items(usedCodes, key = { it }) { code ->
                                             UsedCodeItem(code = code)
                                         }
                                     }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Info
@@ -286,15 +288,16 @@ fun HostDashboardScreen(
                             // 3-2. 리스트 내용
                             if (selectedTabIndex.value == 0) {
                                 // 미참여 리스트 (공유 버튼 있음)
-                                if (response.codes.isEmpty()) {
+                                if (unusedCodes.isEmpty()) {
                                     EmptyStateText("모든 코드가 사용되었습니다! 🎉")
                                 } else {
-                                    unusedCodes.forEach { code ->
-                                        UnusedCodeItem(
-                                            code = code,
-                                            onShare = { handleShareCode(it, response.title) }
-                                        )
-                                        Spacer(modifier = Modifier.height(8.dp))
+                                    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        items(unusedCodes.toList()) { code ->
+                                            UnusedCodeItem(
+                                                code = code,
+                                                onShare = { handleShareCode(it, response.title) }
+                                            )
+                                        }
                                     }
                                 }
                             } else {
@@ -302,9 +305,10 @@ fun HostDashboardScreen(
                                 if (usedCodes.isEmpty()) {
                                     EmptyStateText("아직 투표한 사람이 없습니다.")
                                 } else {
-                                    usedCodes.forEach { code ->
-                                        UsedCodeItem(code = code)
-                                        Spacer(modifier = Modifier.height(8.dp))
+                                    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        items(usedCodes) { code ->
+                                            UsedCodeItem(code = code)
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
@@ -1,17 +1,386 @@
 package com.imeanttobe.consensusapp.ui.host_dashboard
 
+import android.content.Intent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.navigation.Route
+import com.imeanttobe.consensusapp.ui.host_dashboard.components.EmptyStateText
+import com.imeanttobe.consensusapp.ui.host_dashboard.components.FinishConfirmDialog
+import com.imeanttobe.consensusapp.ui.host_dashboard.components.HostDashboardTopBar
+import com.imeanttobe.consensusapp.ui.host_dashboard.components.UnusedCodeItem
+import com.imeanttobe.consensusapp.ui.host_dashboard.components.UsedCodeItem
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun HostDashboardScreen(id: Int) {
-    Scaffold { innerPadding ->
-        Text(
-            text = "Host Dashboard Screen: $id",
-            modifier = Modifier.padding(innerPadding),
+fun HostDashboardScreen(
+    id: Int,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+    viewModel: HostDashboardViewModel = hiltViewModel()
+) {
+    val pollStatusUiState = viewModel.pollStatusUiState.collectAsStateWithLifecycle()
+    val finishPollUiState = viewModel.finishPollUiState.collectAsStateWithLifecycle()
+    val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
+    val finishStatusMessage = viewModel.finishStatusMessage.collectAsStateWithLifecycle()
+    val progress = viewModel.progress.collectAsStateWithLifecycle()
+    val selectedTabIndex = viewModel.selectedTabIndex.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val animateProgress = animateFloatAsState(
+        targetValue = progress.value,
+        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+    )
+    val isFinishButtonEnabled = pollStatusUiState.value is UiState.Success
+            && finishPollUiState.value !is UiState.Loading
+    val tabs = listOf("미참여", "참여")
+
+    val handleNavigateBack: () -> Unit = { navController.popBackStack() }
+    val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
+    val handleDismiss: () -> Unit = { viewModel.setDialogState(false)}
+    val handleTabChange: (index: Int) -> Unit = { viewModel.setSelectedTabIndex(it) }
+    val handleFinish: () -> Unit = {
+        viewModel.setDialogState(false)
+        viewModel.finishPoll()
+    }
+    val handleRefresh: () -> Unit = {
+        viewModel.loadPollStatus(id)
+    }
+    val handleShare: () -> Unit = {
+        val deepLink = "consensus://poll/$id"
+        val shareMessage = """
+            [Consensus 투표 초대]
+            투표에 참여해주세요!
+            
+            👇 아래 링크를 눌러 앱에서 바로 투표하세요:
+            $deepLink
+        """.trimIndent()
+
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, shareMessage)
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, "투표 공유")
+        context.startActivity(shareIntent)
+    }
+    val handleShareCode: (code: String, title: String) -> Unit = { code, title ->
+        // 공유할 메시지 생성
+        val deepLink = "consensus://poll/$id"
+        val shareMessage = """
+            [Consensus 투표 초대]
+            '$title' 투표에 참여해주세요!
+            
+            🔑 참여 코드: $code
+            
+            👇 아래 링크를 눌러 앱에서 바로 투표하세요:
+            $deepLink
+        """.trimIndent()
+
+        // 안드로이드 공유 시트 실행
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, shareMessage)
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, "투표 코드 공유")
+        context.startActivity(shareIntent)
+    }
+
+    LaunchedEffect(key1 = finishPollUiState.value) {
+        when (val finishPollState = finishPollUiState.value) {
+            is UiState.Success -> {
+                navController.navigate(Route.ResultScreen(id)) {
+                    popUpTo(Route.HostDashboardScreen) { inclusive = true }
+                }
+            }
+            is UiState.Failure -> {
+                snackbarHostState.showSnackbar(
+                    message = finishPollState.message,
+                    duration = SnackbarDuration.Short
+                )
+                viewModel.resetFinishPollUiState()
+            }
+            else -> {}
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            HostDashboardTopBar(
+                onBackClicked = handleNavigateBack,
+                onShare = handleShare
+            )
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        when (val pollState = pollStatusUiState.value) {
+            is UiState.Success -> {
+                val response = pollState.data
+                val unusedCodes = response.codes - response.usedCodes.toSet()
+                val usedCodes = response.usedCodes
+
+                Box(
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(24.dp)
+                    ) {
+                        // [1] 상단: 투표 정보
+                        Column {
+                            Text(
+                                text = response.title,
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Info, // 또는 Share 아이콘
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+                                    text = "투표 ID: ${response.id}",
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+
+                        // [2] 중단: 투표 현황 카드
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.elevatedCardColors()
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "현재 참여 현황",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+
+                                // 텍스트로 현황 표시 (예: 3 / 10)
+                                Text(
+                                    text = "${response.usedCodes.size} / ${response.codes.size}",
+                                    style = MaterialTheme.typography.displayMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+
+                                Text(
+                                    text = "명이 투표를 완료했습니다.",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+
+                                Spacer(modifier = Modifier.height(24.dp))
+
+                                // 진행률 바
+                                LinearWavyProgressIndicator(
+                                    progress = { animateProgress.value },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(8.dp)
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+
+                                // 퍼센트 및 새로고침
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        text = "${(progress.value * 100).toInt()}% 달성",
+                                        style = MaterialTheme.typography.labelMedium
+                                    )
+
+                                    // 새로고침 버튼 (작게)
+                                    TextButton(onClick = handleRefresh) {
+                                        Text("새로고침")
+                                    }
+                                }
+                            }
+                        }
+
+                        Column(
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = "투표 코드 관리",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            // 3-1. 탭 행 (Tab Row)
+                            PrimaryTabRow(selectedTabIndex = selectedTabIndex.value) {
+                                tabs.forEachIndexed { index, title ->
+                                    Tab(
+                                        selected = selectedTabIndex.value == index,
+                                        onClick = { handleTabChange(index) },
+                                        text = { Text(text = title) },
+                                        modifier = Modifier.clip(MaterialTheme.shapes.small)
+                                    )
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // 3-2. 리스트 내용
+                            if (selectedTabIndex.value == 0) {
+                                // 미참여 리스트 (공유 버튼 있음)
+                                if (response.codes.isEmpty()) {
+                                    EmptyStateText("모든 코드가 사용되었습니다! 🎉")
+                                } else {
+                                    unusedCodes.forEach { code ->
+                                        UnusedCodeItem(
+                                            code = code,
+                                            onShare = { handleShareCode(it, response.title) }
+                                        )
+                                        Spacer(modifier = Modifier.height(8.dp))
+                                    }
+                                }
+                            } else {
+                                // 참여 완료 리스트 (읽기 전용)
+                                if (usedCodes.isEmpty()) {
+                                    EmptyStateText("아직 투표한 사람이 없습니다.")
+                                } else {
+                                    usedCodes.forEach { code ->
+                                        UsedCodeItem(code = code)
+                                        Spacer(modifier = Modifier.height(8.dp))
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Submit button
+                    Button(
+                        onClick = handleOpenDialog,
+                        enabled = isFinishButtonEnabled,
+                        contentPadding = ButtonDefaults.MediumContentPadding,
+                        modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
+                    ) {
+                        if (finishPollUiState.value is UiState.Loading) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                CircularWavyProgressIndicator(modifier = Modifier.size(ButtonDefaults.MediumIconSize))
+                                Text(
+                                    text = finishStatusMessage.value,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        } else {
+                            Text(text = "마감하기")
+                        }
+                    }
+                }
+            }
+            is UiState.Failure -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(paddingValues = innerPadding)
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ErrorOutline,
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp).padding(bottom = 16.dp)
+                    )
+                    Text(
+                        text = "투표 현황 데이터를 불러오지 못했어요: ${pollState.message}",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+            else -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(paddingValues = innerPadding)
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
+                    CircularWavyProgressIndicator(modifier = Modifier.padding(bottom = 16.dp))
+                    Text(
+                        text = "투표 현황 데이터를 불러오는 중...",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+
+    if (dialogState.value) {
+        FinishConfirmDialog(
+            onConfirm = handleFinish,
+            onDismiss = handleDismiss
         )
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
@@ -1,0 +1,88 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HostDashboardViewModel @Inject constructor(
+    private val pollRepo: PollRepo,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val _pollStatusUiState = MutableStateFlow<UiState<GetPollStatusResponse>>(UiState.Idle)
+    val pollStatusUiState: StateFlow<UiState<GetPollStatusResponse>> = _pollStatusUiState
+
+    private val _finishPollUiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
+    val finishPollUiState: StateFlow<UiState<Unit>> = _finishPollUiState
+
+    private val _finishStatusMessage = MutableStateFlow("")
+    val finishStatusMessage: StateFlow<String> = _finishStatusMessage
+
+    private val _dialogState = MutableStateFlow(false)
+    val dialogState: StateFlow<Boolean> = _dialogState
+
+    private val _progress = MutableStateFlow(0f)
+    val progress: StateFlow<Float> = _progress
+
+    private val _selectedTabIndex = MutableStateFlow(0)
+    val selectedTabIndex: StateFlow<Int> = _selectedTabIndex
+
+    init {
+        val id = savedStateHandle.get<Int>("id") ?: -1
+        loadPollStatus(id)
+    }
+
+    fun resetFinishPollUiState() {
+        _finishPollUiState.value = UiState.Idle
+    }
+
+    fun setDialogState(state: Boolean) {
+        _dialogState.value = state
+    }
+
+    fun setSelectedTabIndex(index: Int) {
+        _selectedTabIndex.value = index
+    }
+
+    fun finishPoll() {
+        _finishPollUiState.value = UiState.Loading
+
+        viewModelScope.launch {
+            val responseBody = pollStatusUiState.value
+            if (responseBody !is UiState.Success) {
+                _finishPollUiState.value = UiState.Failure("Poll data is not loaded")
+                return@launch
+            }
+
+            val result = pollRepo.finishPoll(responseBody.data.id)
+            result.fold(
+                onSuccess = { _finishPollUiState.value = UiState.Success(Unit) },
+                onFailure = { _finishPollUiState.value = UiState.Failure(it.message ?: "Unknown error") }
+            )
+        }
+    }
+
+    fun loadPollStatus(id: Int) {
+        _pollStatusUiState.value = UiState.Loading
+
+        viewModelScope.launch {
+            val result = pollRepo.getPollStatus(id)
+
+            result.fold(
+                onSuccess = {
+                    _pollStatusUiState.value = UiState.Success(it)
+                    _progress.value = it.usedCodes.size.toFloat() / it.codes.size.toFloat()
+                },
+                onFailure = { _pollStatusUiState.value = UiState.Failure(it.message ?: "Unknown error") }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
@@ -37,7 +37,11 @@ class HostDashboardViewModel @Inject constructor(
 
     init {
         val id = savedStateHandle.get<Int>("id") ?: -1
-        loadPollStatus(id)
+        if (id != -1) {
+            loadPollStatus(id)
+        } else {
+            _pollStatusUiState.value = UiState.Failure("Invalid poll id")
+        }
     }
 
     fun resetFinishPollUiState() {
@@ -54,6 +58,7 @@ class HostDashboardViewModel @Inject constructor(
 
     fun finishPoll() {
         _finishPollUiState.value = UiState.Loading
+        _finishStatusMessage.value = "데이터 검증하는 중..."
 
         viewModelScope.launch {
             val responseBody = pollStatusUiState.value
@@ -62,6 +67,7 @@ class HostDashboardViewModel @Inject constructor(
                 return@launch
             }
 
+            _finishStatusMessage.value = "투표 마감 요청 중..."
             val result = pollRepo.finishPoll(responseBody.data.id)
             result.fold(
                 onSuccess = { _finishPollUiState.value = UiState.Success(Unit) },
@@ -77,9 +83,13 @@ class HostDashboardViewModel @Inject constructor(
             val result = pollRepo.getPollStatus(id)
 
             result.fold(
-                onSuccess = {
-                    _pollStatusUiState.value = UiState.Success(it)
-                    _progress.value = it.usedCodes.size.toFloat() / it.codes.size.toFloat()
+                onSuccess = { requestBody ->
+                    _pollStatusUiState.value = UiState.Success(requestBody)
+                    _progress.value = if (requestBody.codes.isNotEmpty()) {
+                        requestBody.usedCodes.size.toFloat() / requestBody.codes.size.toFloat()
+                    } else {
+                        0f
+                    }
                 },
                 onFailure = { _pollStatusUiState.value = UiState.Failure(it.message ?: "Unknown error") }
             )

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/EmptyStateText.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/EmptyStateText.kt
@@ -1,0 +1,27 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyStateText(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/FinishConfirmDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/FinishConfirmDialog.kt
@@ -1,7 +1,6 @@
 package com.imeanttobe.consensusapp.ui.host_dashboard.components
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.HowToVote
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/FinishConfirmDialog.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/FinishConfirmDialog.kt
@@ -1,0 +1,38 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.HowToVote
+import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun FinishConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.WarningAmber,
+                contentDescription = null
+            )
+        },
+        onDismissRequest = onDismiss,
+        title = { Text(text = "투표 마감") },
+        text = { Text(text = "이 작업은 되돌릴 수 없어요. 투표를 마감하시겠어요?") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = "마감")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = "취소")
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/HostDashboardTopBar.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/HostDashboardTopBar.kt
@@ -1,0 +1,38 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HostDashboardTopBar(
+    onBackClicked: () -> Unit,
+    onShare: () -> Unit
+) {
+    CenterAlignedTopAppBar(
+        title = {  },
+        navigationIcon = {
+            IconButton(onClick = onBackClicked) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = null
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = onShare) {
+                Icon(
+                    imageVector = Icons.Outlined.Share,
+                    contentDescription = null
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/HostDashboardTopBar.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/HostDashboardTopBar.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UnusedCodeItem.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UnusedCodeItem.kt
@@ -1,0 +1,67 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun UnusedCodeItem(code: String, onShare: (String) -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Outlined.Lock, // 또는 Key 아이콘
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = code,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = FontFamily.Monospace // 코드 느낌 나게
+                )
+            }
+
+            // 공유 버튼
+            IconButton(onClick = { onShare(code) }) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = "코드 공유",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UsedCodeItem.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UsedCodeItem.kt
@@ -1,0 +1,66 @@
+package com.imeanttobe.consensusapp.ui.host_dashboard.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun UsedCodeItem(code: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f)
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 12.dp) // 버튼이 없으므로 패딩 조정
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = code,
+                    style = MaterialTheme.typography.bodyLarge,
+                    textDecoration = TextDecoration.LineThrough, // 취소선 효과
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                )
+            }
+
+            // 완료 뱃지
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "투표 완료",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UsedCodeItem.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/components/UsedCodeItem.kt
@@ -37,14 +37,12 @@ fun UsedCodeItem(code: String) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = code,
-                    style = MaterialTheme.typography.bodyLarge,
-                    textDecoration = TextDecoration.LineThrough, // 취소선 효과
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                )
-            }
+            Text(
+                text = code,
+                style = MaterialTheme.typography.bodyLarge,
+                textDecoration = TextDecoration.LineThrough, // 취소선 효과
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+            )
 
             // 완료 뱃지
             Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #52 

# 📝 작업 내용
주최자 대시보드 화면을 구현했어요. 또한, 투표 코드 관리를 위해 주최자용 투표 현황 조회 API를 추가했어요.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 호스트 대시보드 전면 개선: 실시간 투표 상태 조회(새 API 연동), 진행률 애니메이션 및 새로고침
  * 투표 마감 흐름 추가: 마감 확인 대화상자, 로딩/완료/오류 처리 및 결과 화면 이동
  * 전체 초대 및 개별 코드 공유 인텐트 연동
  * 개발용 페이크 데이터로 로컬 미리보기 지원

* **UI 컴포넌트**
  * 빈 상태 텍스트, 상단바, 미사용/사용 코드 항목 등 재사용 가능한 구성요소 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->