### PR TITLE
[FEAT] 투표 마감 화면 구현

### DIFF
--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/FakePollRepoImpl.kt
@@ -1,9 +1,11 @@
 package com.imeanttobe.consensusapp.data.repo
 
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.FinishPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
+import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultResponse
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import kotlinx.coroutines.delay
 
@@ -33,8 +35,8 @@ class FakePollRepoImpl : PollRepo {
         return Result.success(Unit)
     }
 
-    override suspend fun finishPoll(id: Int): Result<Unit> {
-        return Result.success(Unit)
+    override suspend fun finishPoll(id: Int): Result<FinishPollResponse> {
+        return Result.success(FinishPollResponse.getFakeData())
     }
 
     override suspend fun getPollResult(id: Int): Result<GetPollResultResponse> {
@@ -44,7 +46,7 @@ class FakePollRepoImpl : PollRepo {
     override suspend fun submitPollResult(
         id: Int,
         votes: List<Int>
-    ): Result<Unit> {
-        return Result.success(Unit)
+    ): Result<SubmitPollResultResponse> {
+        return Result.success(SubmitPollResultResponse.getFakeData())
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -77,13 +77,9 @@ class PollRepoImpl @Inject constructor(
             val response = pollApi.submitPollResult(id, request)
 
             if (response.isSuccessful) {
-                val body = response.body()
-
-                if (body != null) {
+                response.body()?.let { body ->
                     Result.success(body)
-                } else {
-                    Result.failure(Exception("Response body is null"))
-                }
+                } ?: Result.failure(Exception("Response body is null"))
             } else {
                 Result.failure(Exception(response.message()))
             }
@@ -149,7 +145,7 @@ class PollRepoImpl @Inject constructor(
                 } else {
                     Result.failure(Exception("Response body is null"))
                 }
-            }else {
+            } else {
                 Result.failure(Exception(response.message()))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/data/repo/PollRepoImpl.kt
@@ -3,10 +3,12 @@ package com.imeanttobe.consensusapp.data.repo
 import com.imeanttobe.consensusapp.data.remote.api.PollApi
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollRequest
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.FinishPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
 import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultRequest
+import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultResponse
 import com.imeanttobe.consensusapp.data.remote.dto.VoteRequest
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import javax.inject.Inject
@@ -69,13 +71,19 @@ class PollRepoImpl @Inject constructor(
         }
     }
 
-    override suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit> {
+    override suspend fun submitPollResult(id: Int, votes: List<Int>): Result<SubmitPollResultResponse> {
         return try {
             val request = SubmitPollResultRequest(votes)
             val response = pollApi.submitPollResult(id, request)
 
             if (response.isSuccessful) {
-                Result.success(Unit)
+                val body = response.body()
+
+                if (body != null) {
+                    Result.success(body)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
             } else {
                 Result.failure(Exception(response.message()))
             }
@@ -129,13 +137,19 @@ class PollRepoImpl @Inject constructor(
         }
     }
 
-    override suspend fun finishPoll(id: Int): Result<Unit> {
+    override suspend fun finishPoll(id: Int): Result<FinishPollResponse> {
         return try {
             val response = pollApi.finishPoll(id)
 
             if (response.isSuccessful) {
-                Result.success(Unit)
-            } else {
+                val body = response.body()
+
+                if (body != null) {
+                    Result.success(body)
+                } else {
+                    Result.failure(Exception("Response body is null"))
+                }
+            }else {
                 Result.failure(Exception(response.message()))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollInfoItemsRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollInfoItemsRepo.kt
@@ -1,7 +1,6 @@
 package com.imeanttobe.consensusapp.domain.repo
 
 import com.imeanttobe.consensusapp.PollInfo
-import com.imeanttobe.consensusapp.domain.model.PollUiModel
 
 interface PollInfoItemsRepo {
     suspend fun getAllPollInfo(): Result<List<PollInfo>>

--- a/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/domain/repo/PollRepo.kt
@@ -1,16 +1,18 @@
 package com.imeanttobe.consensusapp.domain.repo
 
 import com.imeanttobe.consensusapp.data.remote.dto.CreatePollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.FinishPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollResultResponse
 import com.imeanttobe.consensusapp.data.remote.dto.GetPollStatusResponse
+import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultResponse
 
 interface PollRepo {
     suspend fun getPoll(id: Int): Result<GetPollResponse>
     suspend fun vote(id: Int, vote: String, code: String): Result<Unit>
-    suspend fun finishPoll(id: Int): Result<Unit>
+    suspend fun finishPoll(id: Int): Result<FinishPollResponse>
     suspend fun getPollResult(id: Int): Result<GetPollResultResponse>
-    suspend fun submitPollResult(id: Int, votes: List<Int>): Result<Unit>
+    suspend fun submitPollResult(id: Int, votes: List<Int>): Result<SubmitPollResultResponse>
     suspend fun createPoll(title: String, pk: String, candidates: List<String>): Result<CreatePollResponse>
     suspend fun getPollStatus(id: Int): Result<GetPollStatusResponse>
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
@@ -28,5 +28,8 @@ sealed interface Route {
     data class WaitingScreen(val id: Int) : Route
 
     @Serializable
-    data class ResultScreen(val id: Int) : Route
+    data class PollResultScreen(val id: Int) : Route
+
+    @Serializable
+    data class PollFinishScreen(val id: Int) : Route)
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/navigation/Route.kt
@@ -31,5 +31,5 @@ sealed interface Route {
     data class PollResultScreen(val id: Int) : Route
 
     @Serializable
-    data class PollFinishScreen(val id: Int) : Route)
+    data class PollFinishScreen(val id: Int) : Route
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -12,6 +12,7 @@ import com.imeanttobe.consensusapp.ui.create_poll.CreatePollScreen
 import com.imeanttobe.consensusapp.ui.dev.DevScreen
 import com.imeanttobe.consensusapp.ui.home.HomeScreen
 import com.imeanttobe.consensusapp.ui.host_dashboard.HostDashboardScreen
+import com.imeanttobe.consensusapp.ui.poll_finish.PollFinishScreen
 import com.imeanttobe.consensusapp.ui.poll_result.PollResultScreen
 import com.imeanttobe.consensusapp.ui.splash.SplashScreen
 import com.imeanttobe.consensusapp.ui.vote.VoteScreen
@@ -56,8 +57,8 @@ fun ConsensusNavGraph() {
             VoteScreen(id = route.id, navController = navController)
         }
 
-        composable<Route.ResultScreen> { backStackEntry ->
-            val route: Route.ResultScreen = backStackEntry.toRoute()
+        composable<Route.PollResultScreen> { backStackEntry ->
+            val route: Route.PollResultScreen = backStackEntry.toRoute()
             PollResultScreen(id = route.id)
         }
 
@@ -74,6 +75,11 @@ fun ConsensusNavGraph() {
         composable<Route.WaitingScreen> { backStackEntry ->
             val route: Route.WaitingScreen = backStackEntry.toRoute()
             WaitingScreen(id = route.id)
+        }
+
+        composable<Route.PollFinishScreen> { backStackEntry ->
+            val route: Route.PollFinishScreen = backStackEntry.toRoute()
+            PollFinishScreen(id = route.id)
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -79,7 +79,7 @@ fun ConsensusNavGraph() {
 
         composable<Route.PollFinishScreen> { backStackEntry ->
             val route: Route.PollFinishScreen = backStackEntry.toRoute()
-            PollFinishScreen(id = route.id)
+            PollFinishScreen(id = route.id, navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/ConsensusNavGraph.kt
@@ -12,7 +12,7 @@ import com.imeanttobe.consensusapp.ui.create_poll.CreatePollScreen
 import com.imeanttobe.consensusapp.ui.dev.DevScreen
 import com.imeanttobe.consensusapp.ui.home.HomeScreen
 import com.imeanttobe.consensusapp.ui.host_dashboard.HostDashboardScreen
-import com.imeanttobe.consensusapp.ui.result.ResultScreen
+import com.imeanttobe.consensusapp.ui.poll_result.PollResultScreen
 import com.imeanttobe.consensusapp.ui.splash.SplashScreen
 import com.imeanttobe.consensusapp.ui.vote.VoteScreen
 import com.imeanttobe.consensusapp.ui.vote_result.VoteResultScreen
@@ -58,7 +58,7 @@ fun ConsensusNavGraph() {
 
         composable<Route.ResultScreen> { backStackEntry ->
             val route: Route.ResultScreen = backStackEntry.toRoute()
-            ResultScreen(id = route.id)
+            PollResultScreen(id = route.id)
         }
 
         composable<Route.VoteResultScreen> { backStackEntry ->

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/dev/DevScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/dev/DevScreen.kt
@@ -49,7 +49,7 @@ fun DevScreen(
                 Text(text = "Vote")
             }
 
-            Button(onClick = { navController.navigate(Route.ResultScreen(id = 0)) }) {
+            Button(onClick = { navController.navigate(Route.PollResultScreen(id = 0)) }) {
                 Text(text = "Result")
             }
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardScreen.kt
@@ -65,9 +65,7 @@ fun HostDashboardScreen(
     viewModel: HostDashboardViewModel = hiltViewModel()
 ) {
     val pollStatusUiState = viewModel.pollStatusUiState.collectAsStateWithLifecycle()
-    val finishPollUiState = viewModel.finishPollUiState.collectAsStateWithLifecycle()
     val dialogState = viewModel.dialogState.collectAsStateWithLifecycle()
-    val finishStatusMessage = viewModel.finishStatusMessage.collectAsStateWithLifecycle()
     val progress = viewModel.progress.collectAsStateWithLifecycle()
     val selectedTabIndex = viewModel.selectedTabIndex.collectAsStateWithLifecycle()
 
@@ -78,77 +76,49 @@ fun HostDashboardScreen(
         animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
     )
     val isFinishButtonEnabled = pollStatusUiState.value is UiState.Success
-            && finishPollUiState.value !is UiState.Loading
     val tabs = listOf("미참여", "참여")
+    val openShareIntent: (title: String, content: String) -> Unit = { title, content ->
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, content)
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, title)
+        context.startActivity(shareIntent)
+    }
 
     val handleNavigateBack: () -> Unit = { navController.popBackStack() }
     val handleOpenDialog: () -> Unit = { viewModel.setDialogState(true) }
     val handleDismiss: () -> Unit = { viewModel.setDialogState(false)}
     val handleTabChange: (index: Int) -> Unit = { viewModel.setSelectedTabIndex(it) }
+    val handleRefresh: () -> Unit = { viewModel.loadPollStatus(id) }
     val handleFinish: () -> Unit = {
         viewModel.setDialogState(false)
-        viewModel.finishPoll()
-    }
-    val handleRefresh: () -> Unit = {
-        viewModel.loadPollStatus(id)
+        navController.navigate(Route.PollFinishScreen(id = id))
     }
     val handleShare: () -> Unit = {
-        val deepLink = "consensus://poll/$id"
-        val shareMessage = """
+        val content = """
             [Consensus 투표 초대]
             투표에 참여해주세요!
             
             👇 아래 링크를 눌러 앱에서 바로 투표하세요:
-            $deepLink
+            consensus://poll/$id
         """.trimIndent()
-
-        val sendIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, shareMessage)
-            type = "text/plain"
-        }
-        val shareIntent = Intent.createChooser(sendIntent, "투표 공유")
-        context.startActivity(shareIntent)
+        val title = "투표 공유"
+        openShareIntent(title, content)
     }
-    val handleShareCode: (code: String, title: String) -> Unit = { code, title ->
-        // 공유할 메시지 생성
-        val deepLink = "consensus://poll/$id"
-        val shareMessage = """
+    val handleShareCode: (code: String, pollTitle: String) -> Unit = { code, pollTitle ->
+        val content = """
             [Consensus 투표 초대]
-            '$title' 투표에 참여해주세요!
+            '$pollTitle' 투표에 참여해주세요!
             
             🔑 참여 코드: $code
             
             👇 아래 링크를 눌러 앱에서 바로 투표하세요:
-            $deepLink
+            consensus://poll/$id
         """.trimIndent()
-
-        // 안드로이드 공유 시트 실행
-        val sendIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, shareMessage)
-            type = "text/plain"
-        }
-        val shareIntent = Intent.createChooser(sendIntent, "투표 코드 공유")
-        context.startActivity(shareIntent)
-    }
-
-    LaunchedEffect(key1 = finishPollUiState.value) {
-        when (val finishPollState = finishPollUiState.value) {
-            is UiState.Success -> {
-                navController.navigate(Route.ResultScreen(id)) {
-                    popUpTo(Route.HostDashboardScreen) { inclusive = true }
-                }
-            }
-            is UiState.Failure -> {
-                snackbarHostState.showSnackbar(
-                    message = finishPollState.message,
-                    duration = SnackbarDuration.Short
-                )
-                viewModel.resetFinishPollUiState()
-            }
-            else -> {}
-        }
+        val title = "투표 코드 공유"
+        openShareIntent(title, content)
     }
 
     Scaffold(
@@ -322,20 +292,7 @@ fun HostDashboardScreen(
                         contentPadding = ButtonDefaults.MediumContentPadding,
                         modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp)
                     ) {
-                        if (finishPollUiState.value is UiState.Loading) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                CircularWavyProgressIndicator(modifier = Modifier.size(ButtonDefaults.MediumIconSize))
-                                Text(
-                                    text = finishStatusMessage.value,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                        } else {
-                            Text(text = "마감하기")
-                        }
+                        Text(text = "마감하기")
                     }
                 }
             }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/host_dashboard/HostDashboardViewModel.kt
@@ -20,12 +20,6 @@ class HostDashboardViewModel @Inject constructor(
     private val _pollStatusUiState = MutableStateFlow<UiState<GetPollStatusResponse>>(UiState.Idle)
     val pollStatusUiState: StateFlow<UiState<GetPollStatusResponse>> = _pollStatusUiState
 
-    private val _finishPollUiState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
-    val finishPollUiState: StateFlow<UiState<Unit>> = _finishPollUiState
-
-    private val _finishStatusMessage = MutableStateFlow("")
-    val finishStatusMessage: StateFlow<String> = _finishStatusMessage
-
     private val _dialogState = MutableStateFlow(false)
     val dialogState: StateFlow<Boolean> = _dialogState
 
@@ -44,36 +38,12 @@ class HostDashboardViewModel @Inject constructor(
         }
     }
 
-    fun resetFinishPollUiState() {
-        _finishPollUiState.value = UiState.Idle
-    }
-
     fun setDialogState(state: Boolean) {
         _dialogState.value = state
     }
 
     fun setSelectedTabIndex(index: Int) {
         _selectedTabIndex.value = index
-    }
-
-    fun finishPoll() {
-        _finishPollUiState.value = UiState.Loading
-        _finishStatusMessage.value = "데이터 검증하는 중..."
-
-        viewModelScope.launch {
-            val responseBody = pollStatusUiState.value
-            if (responseBody !is UiState.Success) {
-                _finishPollUiState.value = UiState.Failure("Poll data is not loaded")
-                return@launch
-            }
-
-            _finishStatusMessage.value = "투표 마감 요청 중..."
-            val result = pollRepo.finishPoll(responseBody.data.id)
-            result.fold(
-                onSuccess = { _finishPollUiState.value = UiState.Success(Unit) },
-                onFailure = { _finishPollUiState.value = UiState.Failure(it.message ?: "Unknown error") }
-            )
-        }
     }
 
     fun loadPollStatus(id: Int) {

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
@@ -1,12 +1,77 @@
 package com.imeanttobe.consensusapp.ui.poll_finish
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.imeanttobe.consensusapp.core.UiState
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun PollFinishScreen(id: Int) {
-    Scaffold() {
-        Text(text = "Hello $id")
+fun PollFinishScreen(
+    modifier: Modifier = Modifier,
+    viewModel: PollFinishViewModel = hiltViewModel()
+) {
+    val finishPollUiState = viewModel.finishPollUiState.collectAsStateWithLifecycle()
+    val submitPollResultUiState = viewModel.submitPollResultUiState.collectAsStateWithLifecycle()
+    val statusMessage = viewModel.statusMessage.collectAsStateWithLifecycle()
+
+    LaunchedEffect(key1 = finishPollUiState.value) {
+        when (val state = finishPollUiState.value) {
+            is UiState.Success -> {
+
+            }
+            is UiState.Failure -> {
+
+            }
+            else -> {}
+        }
     }
+
+    LaunchedEffect(key1 = submitPollResultUiState.value) {
+        when (val state = submitPollResultUiState.value) {
+            is UiState.Success -> {
+
+            }
+            is UiState.Failure -> {
+
+            }
+            else -> {}
+        }
+    }
+
+    Scaffold(
+        modifier = modifier
+    ) { innerPadding ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            // Loading indicator
+            CircularWavyProgressIndicator(modifier = Modifier.padding(vertical = 16.dp))
+
+            // Loading message
+            Text(
+                text = statusMessage.value,
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+    }
+
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
@@ -8,51 +8,61 @@ import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.navigation.Route
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PollFinishScreen(
+    id: Int,
+    navController: NavHostController,
     modifier: Modifier = Modifier,
     viewModel: PollFinishViewModel = hiltViewModel()
 ) {
-    val finishPollUiState = viewModel.finishPollUiState.collectAsStateWithLifecycle()
     val submitPollResultUiState = viewModel.submitPollResultUiState.collectAsStateWithLifecycle()
     val statusMessage = viewModel.statusMessage.collectAsStateWithLifecycle()
 
-    LaunchedEffect(key1 = finishPollUiState.value) {
-        when (val state = finishPollUiState.value) {
-            is UiState.Success -> {
-
-            }
-            is UiState.Failure -> {
-
-            }
-            else -> {}
-        }
-    }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     LaunchedEffect(key1 = submitPollResultUiState.value) {
         when (val state = submitPollResultUiState.value) {
             is UiState.Success -> {
-
+                navController.navigate(Route.PollResultScreen(id = id)) {
+                    popUpTo(Route.HostDashboardScreen) { inclusive = true }
+                }
             }
             is UiState.Failure -> {
-
+                scope.launch {
+                    val message = "투표 완료 처리 실패. 원인: ${state.message}"
+                    snackbarHostState.showSnackbar(
+                        message = message,
+                        duration = SnackbarDuration.Short
+                    )
+                }
+                navController.popBackStack()
             }
             else -> {}
         }
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         modifier = modifier
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
@@ -1,0 +1,12 @@
+package com.imeanttobe.consensusapp.ui.poll_finish
+
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun PollFinishScreen(id: Int) {
+    Scaffold() {
+        Text(text = "Hello $id")
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -24,7 +23,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.imeanttobe.consensusapp.core.UiState
 import com.imeanttobe.consensusapp.navigation.Route
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -38,7 +36,6 @@ fun PollFinishScreen(
     val statusMessage = viewModel.statusMessage.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     LaunchedEffect(key1 = submitPollResultUiState.value) {
         when (val state = submitPollResultUiState.value) {
@@ -48,13 +45,11 @@ fun PollFinishScreen(
                 }
             }
             is UiState.Failure -> {
-                scope.launch {
-                    val message = "투표 완료 처리 실패. 원인: ${state.message}"
-                    snackbarHostState.showSnackbar(
-                        message = message,
-                        duration = SnackbarDuration.Short
-                    )
-                }
+                val message = "투표 완료 처리 실패. 원인: ${state.message}"
+                snackbarHostState.showSnackbar(
+                    message = message,
+                    duration = SnackbarDuration.Short
+                )
                 navController.popBackStack()
             }
             else -> {}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
@@ -1,0 +1,117 @@
+package com.imeanttobe.consensusapp.ui.poll_finish
+
+import android.util.Base64
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.imeanttobe.consensusapp.core.UiState
+import com.imeanttobe.consensusapp.core.crypto.CryptoManager
+import com.imeanttobe.consensusapp.data.remote.dto.FinishPollResponse
+import com.imeanttobe.consensusapp.data.remote.dto.SubmitPollResultResponse
+import com.imeanttobe.consensusapp.domain.repo.PollInfoItemsRepo
+import com.imeanttobe.consensusapp.domain.repo.PollRepo
+import com.imeanttobe.consensusapp.seal.NativeLib
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.lang.annotation.Native
+import javax.inject.Inject
+
+@HiltViewModel
+class PollFinishViewModel @Inject constructor(
+    private val pollRepo: PollRepo,
+    private val pollInfoItemsRepo: PollInfoItemsRepo,
+    private val cryptoManager: CryptoManager,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val _finishPollUiState = MutableStateFlow<UiState<FinishPollResponse>>(UiState.Idle)
+    val finishPollUiState: StateFlow<UiState<FinishPollResponse>> = _finishPollUiState
+
+    private val _submitPollResultUiState = MutableStateFlow<UiState<SubmitPollResultResponse>>(UiState.Idle)
+    val submitPollResultUiState: StateFlow<UiState<SubmitPollResultResponse>> = _submitPollResultUiState
+
+    private val _statusMessage = MutableStateFlow("")
+    val statusMessage: StateFlow<String> = _statusMessage
+
+    init {
+        val id = savedStateHandle.get<Int>("id") ?: -1
+
+        if (id != -1) {
+            finishPoll(id = id)
+        } else {
+            _finishPollUiState.value = UiState.Failure("Invalid poll id")
+        }
+    }
+
+    private fun finishPoll(id: Int) {
+        _finishPollUiState.value = UiState.Loading
+
+        viewModelScope.launch {
+            val response = pollRepo.finishPoll(id = id)
+            response.fold(
+                onSuccess = { responseBody ->
+                    _finishPollUiState.value = UiState.Success(responseBody)
+                    submitPollResult(id = id, encryptedVotes = responseBody.votes)
+                },
+                onFailure = { _finishPollUiState.value = UiState.Failure(it.message ?: "Unknown error") }
+            )
+        }
+    }
+
+    private fun submitPollResult(id: Int, encryptedVotes: List<String>) {
+        _submitPollResultUiState.value = UiState.Loading
+
+        viewModelScope.launch {
+            // Get sk from repo
+            val request = pollInfoItemsRepo.getPollInfo(id)
+            if (request.isSuccess) {
+                val pollInfo = request.getOrNull()
+                if (pollInfo != null) {
+                    // Decrypt sk
+                    val decryptedSk = cryptoManager.decrypt(
+                        ciphertext = pollInfo.encryptedSk.toByteArray(),
+                        iv = pollInfo.iv.toByteArray()
+                    )
+
+                    // Decode Base64 votes
+                    val decodedVotes = encryptedVotes.map { Base64.decode(it, Base64.NO_WRAP) }
+
+                    // Sum all votes
+                    var sum = decodedVotes.first()
+                    for (i in 1 until decodedVotes.size) {
+                        val addValue = NativeLib.addCiphertexts(sum, decodedVotes[i])
+                        if (addValue != null) {
+                            sum = addValue
+                        } else {
+                            _submitPollResultUiState.value = UiState.Failure("Failed to add votes")
+                            return@launch
+                        }
+                    }
+
+                    // Decrypt sum
+                    val decryptedSum = NativeLib.decrypt(sum)
+                    if (decryptedSum != null) {
+                        // Send result to server
+                        val result = pollRepo.submitPollResult(id = id, votes = decryptedSum.map { it.toInt() })
+                        result.fold(
+                            onSuccess = { responseBody ->
+                                _submitPollResultUiState.value = UiState.Success(responseBody)
+                                _statusMessage.value = "투표가 완료되었습니다."
+                            },
+                            onFailure = { _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error") }
+                        )
+                    } else {
+                        _submitPollResultUiState.value = UiState.Failure("Failed to decrypt sum")
+                        return@launch
+                    }
+                } else {
+                    _submitPollResultUiState.value = UiState.Failure("Poll info not found")
+                    return@launch
+                }
+            } else {
+                _submitPollResultUiState.value = UiState.Failure(request.exceptionOrNull()?.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
@@ -12,10 +12,12 @@ import com.imeanttobe.consensusapp.domain.repo.PollInfoItemsRepo
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import com.imeanttobe.consensusapp.seal.NativeLib
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.lang.annotation.Native
 import javax.inject.Inject
 
@@ -32,7 +34,7 @@ class PollFinishViewModel @Inject constructor(
     private val _submitPollResultUiState = MutableStateFlow<UiState<SubmitPollResultResponse>>(UiState.Idle)
     val submitPollResultUiState: StateFlow<UiState<SubmitPollResultResponse>> = _submitPollResultUiState
 
-    private val _statusMessage = MutableStateFlow("투표 완료 준비 중...")
+    private val _statusMessage = MutableStateFlow("투표 마감 준비 중...")
     val statusMessage: StateFlow<String> = _statusMessage
 
     init {
@@ -66,10 +68,10 @@ class PollFinishViewModel @Inject constructor(
      */
     private fun finishPoll(id: Int) {
         _finishPollUiState.value = UiState.Loading
+        _statusMessage.value = "투표 마감 요청 중..."
 
         viewModelScope.launch {
             val response = pollRepo.finishPoll(id = id)
-            delay(130000000)
             response.fold(
                 onSuccess = { responseBody ->
                     _finishPollUiState.value = UiState.Success(responseBody)
@@ -95,56 +97,78 @@ class PollFinishViewModel @Inject constructor(
     private fun submitPollResult(id: Int, encryptedVotes: List<String>) {
         _submitPollResultUiState.value = UiState.Loading
 
-        viewModelScope.launch {
-            // 3. Decode given list
-            val decodedEncryptedVotes = encryptedVotes.map { Base64.decode(it, Base64.NO_WRAP) }
-
-            // 4. Get encrypted SK and IV from PollInfoItemsRepo
-            pollInfoItemsRepo.getPollInfo(id).fold(
-                onSuccess = { pollInfo ->
-                    // 5. Decrypt SK with CryptoManager
-                    val decryptedSk = cryptoManager.decrypt(
-                        ciphertext = pollInfo.encryptedSk.toByteArray(),
-                        iv = pollInfo.iv.toByteArray()
-                    )
-
-                    // 6. Sum all encoded and encrypted list with SEAL
-                    var sum = decodedEncryptedVotes.first()
-                    for (i in 1 until decodedEncryptedVotes.size) {
-                        val addValue = NativeLib.addCiphertexts(sum, decodedEncryptedVotes[i])
-                        if (addValue == null) {
-                            _submitPollResultUiState.value = UiState.Failure("Failed to add votes")
-                            return@launch
-                        }
-                        sum = addValue
+        viewModelScope.launch(Dispatchers.Default) {
+            try {
+                // 2-1. Check whether votes are empty
+                if (encryptedVotes.isEmpty()) {
+                    withContext(Dispatchers.Main) {
+                        _statusMessage.value = "투표자가 없습니다."
+                        _submitPollResultUiState.value = UiState.Failure("No votes found")
                     }
-
-                    // 7. Decrypt sum with SEAL
-                    val decryptedSum = NativeLib.decrypt(sum)
-                    if (decryptedSum == null) {
-                        _submitPollResultUiState.value = UiState.Failure("Failed to decrypt sum")
-                        return@launch
-                    }
-                    val payload = decryptedSum.map { it.toInt() }
-
-                    // 8. Send result to server
-                    val submitPollResultRequest = pollRepo.submitPollResult(id = id, votes = payload)
-                    submitPollResultRequest.fold(
-                        onSuccess = { responseBody ->
-                            _submitPollResultUiState.value = UiState.Success(responseBody)
-                            _statusMessage.value = "투표 마감 완료!"
-                        },
-                        onFailure = {
-                            _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
-                            return@launch
-                        }
-                    )
-                },
-                onFailure = {
-                    _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
                     return@launch
                 }
-            )
+
+                // 3. Decode given list
+                _statusMessage.value = "투표 집계 준비 중..."
+                val decodedEncryptedVotes = encryptedVotes.map { Base64.decode(it, Base64.NO_WRAP) }
+
+                // 4. Get encrypted SK and IV from PollInfoItemsRepo
+                pollInfoItemsRepo.getPollInfo(id).fold(
+                    onSuccess = { pollInfo ->
+                        // 5. Decrypt SK with CryptoManager
+                        val decryptedSk = cryptoManager.decrypt(
+                            ciphertext = pollInfo.encryptedSk.toByteArray(),
+                            iv = pollInfo.iv.toByteArray()
+                        )
+
+                        // 6. Sum all encoded and encrypted list with SEAL
+                        _statusMessage.value = "암호화된 투표 값 합산 중..."
+                        var sum = decodedEncryptedVotes.firstOrNull()
+                        if (sum == null) {
+                            _submitPollResultUiState.value = UiState.Failure("Failed to get encrypted votes")
+                            return@launch
+                        }
+
+                        for (i in 1 until decodedEncryptedVotes.size) {
+                            val addValue = NativeLib.addCiphertexts(sum, decodedEncryptedVotes[i])
+                            if (addValue == null) {
+                                _submitPollResultUiState.value = UiState.Failure("Failed to add votes")
+                                return@launch
+                            }
+                            sum = addValue
+                        }
+
+                        // 7. Decrypt sum with SEAL
+                        _statusMessage.value = "결과 복호화 중..."
+                        val decryptedSum = NativeLib.decrypt(sum)
+                        if (decryptedSum == null) {
+                            _submitPollResultUiState.value = UiState.Failure("Failed to decrypt sum")
+                            return@launch
+                        }
+                        val payload = decryptedSum.map { it.toInt() }
+
+                        // 8. Send result to server
+                        val submitPollResultRequest = pollRepo.submitPollResult(id = id, votes = payload)
+                        withContext(Dispatchers.Main) {
+                            submitPollResultRequest.fold(
+                                onSuccess = { responseBody ->
+                                    _submitPollResultUiState.value = UiState.Success(responseBody)
+                                    _statusMessage.value = "투표 마감 완료!"
+                                },
+                                onFailure = {
+                                    _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
+                                }
+                            )
+                        }
+                    },
+                    onFailure = {
+                        _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
+                        return@launch
+                    }
+                )
+            } catch (e: Exception) {
+                _submitPollResultUiState.value = UiState.Failure(e.message ?: "Unknown error")
+            }
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
@@ -13,12 +13,10 @@ import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import com.imeanttobe.consensusapp.seal.NativeLib
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.lang.annotation.Native
 import javax.inject.Inject
 
 @HiltViewModel
@@ -44,6 +42,7 @@ class PollFinishViewModel @Inject constructor(
             finishPoll(id = id)
         } else {
             _finishPollUiState.value = UiState.Failure("Invalid poll id")
+            _submitPollResultUiState.value = UiState.Failure("Invalid poll id")
         }
     }
 
@@ -123,11 +122,7 @@ class PollFinishViewModel @Inject constructor(
 
                         // 6. Sum all encoded and encrypted list with SEAL
                         _statusMessage.value = "암호화된 투표 값 합산 중..."
-                        var sum = decodedEncryptedVotes.firstOrNull()
-                        if (sum == null) {
-                            _submitPollResultUiState.value = UiState.Failure("Failed to get encrypted votes")
-                            return@launch
-                        }
+                        var sum = decodedEncryptedVotes.first()
 
                         for (i in 1 until decodedEncryptedVotes.size) {
                             val addValue = NativeLib.addCiphertexts(sum, decodedEncryptedVotes[i])
@@ -140,7 +135,7 @@ class PollFinishViewModel @Inject constructor(
 
                         // 7. Decrypt sum with SEAL
                         _statusMessage.value = "결과 복호화 중..."
-                        val decryptedSum = NativeLib.decrypt(sum)
+                        val decryptedSum = NativeLib.decrypt(cipherBytes = sum, secretKeyBytes = decryptedSk)
                         if (decryptedSum == null) {
                             _submitPollResultUiState.value = UiState.Failure("Failed to decrypt sum")
                             return@launch

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_finish/PollFinishViewModel.kt
@@ -12,6 +12,7 @@ import com.imeanttobe.consensusapp.domain.repo.PollInfoItemsRepo
 import com.imeanttobe.consensusapp.domain.repo.PollRepo
 import com.imeanttobe.consensusapp.seal.NativeLib
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -31,7 +32,7 @@ class PollFinishViewModel @Inject constructor(
     private val _submitPollResultUiState = MutableStateFlow<UiState<SubmitPollResultResponse>>(UiState.Idle)
     val submitPollResultUiState: StateFlow<UiState<SubmitPollResultResponse>> = _submitPollResultUiState
 
-    private val _statusMessage = MutableStateFlow("")
+    private val _statusMessage = MutableStateFlow("투표 완료 준비 중...")
     val statusMessage: StateFlow<String> = _statusMessage
 
     init {
@@ -44,11 +45,31 @@ class PollFinishViewModel @Inject constructor(
         }
     }
 
+    /**
+     * # 동작 플로우
+     * 1. 투표가 마감됐음을 서버에 알린다.
+     * 2. 응답으로 모든 암호화/인코딩된 투표 값 리스트(List<Base64 String>)를 받는다.
+     * 3. 인코딩된 리스트를 디코딩한다.
+     * 4. PollInfoItemsRepo에서 투표 ID에 맞는 암호화된 SK, IV를 꺼낸다.
+     * 5. SK는 CryptoManager로 복호화한다.
+     * 6. 인코딩된 리스트를 암호화된 상태로 모두 더한다.
+     * 7. 더한 결과를 SK로 복호화하여 최종 투표 결과를 계산한다.
+     * 8. 최종 투표 결과를 서버에 전송한다.
+     * 9. 전송이 성공적으로 완료되었다면 투표 결과 화면 PollResultScreen으로 이동한다.
+     */
+
+    /**
+     * 투표 마감 함수. 투표가 마감되었음을 서버에 알립니다.
+     * 1. 투표가 마감됐음을 서버에 알린다.
+     * 2. 응답으로 모든 암호화/인코딩된 투표 값 리스트(List<Base64 String>)를 받는다.
+     * @param id 마감할 투표의 ID
+     */
     private fun finishPoll(id: Int) {
         _finishPollUiState.value = UiState.Loading
 
         viewModelScope.launch {
             val response = pollRepo.finishPoll(id = id)
+            delay(130000000)
             response.fold(
                 onSuccess = { responseBody ->
                     _finishPollUiState.value = UiState.Success(responseBody)
@@ -59,59 +80,71 @@ class PollFinishViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 투표 결과 취합 및 계산 함수. 암호화된 투표 값을 모두 더하고 복호화한 후, 이를 서버에 전송합니다.
+     * 3. 인코딩된 리스트를 디코딩한다.
+     * 4. PollInfoItemsRepo에서 투표 ID에 맞는 암호화된 SK, IV를 꺼낸다.
+     * 5. SK는 CryptoManager로 복호화한다.
+     * 6. 인코딩된 리스트를 암호화된 상태로 모두 더한다.
+     * 7. 더한 결과를 SK로 복호화하여 최종 투표 결과를 계산한다.
+     * 8. 최종 투표 결과를 서버에 전송한다.
+     * 9. 전송이 성공적으로 완료되었다면 투표 결과 화면 PollResultScreen으로 이동한다.
+     * @param id 투표의 ID
+     * @param encryptedVotes 암호화된 투표 값 리스트
+     */
     private fun submitPollResult(id: Int, encryptedVotes: List<String>) {
         _submitPollResultUiState.value = UiState.Loading
 
         viewModelScope.launch {
-            // Get sk from repo
-            val request = pollInfoItemsRepo.getPollInfo(id)
-            if (request.isSuccess) {
-                val pollInfo = request.getOrNull()
-                if (pollInfo != null) {
-                    // Decrypt sk
+            // 3. Decode given list
+            val decodedEncryptedVotes = encryptedVotes.map { Base64.decode(it, Base64.NO_WRAP) }
+
+            // 4. Get encrypted SK and IV from PollInfoItemsRepo
+            pollInfoItemsRepo.getPollInfo(id).fold(
+                onSuccess = { pollInfo ->
+                    // 5. Decrypt SK with CryptoManager
                     val decryptedSk = cryptoManager.decrypt(
                         ciphertext = pollInfo.encryptedSk.toByteArray(),
                         iv = pollInfo.iv.toByteArray()
                     )
 
-                    // Decode Base64 votes
-                    val decodedVotes = encryptedVotes.map { Base64.decode(it, Base64.NO_WRAP) }
-
-                    // Sum all votes
-                    var sum = decodedVotes.first()
-                    for (i in 1 until decodedVotes.size) {
-                        val addValue = NativeLib.addCiphertexts(sum, decodedVotes[i])
-                        if (addValue != null) {
-                            sum = addValue
-                        } else {
+                    // 6. Sum all encoded and encrypted list with SEAL
+                    var sum = decodedEncryptedVotes.first()
+                    for (i in 1 until decodedEncryptedVotes.size) {
+                        val addValue = NativeLib.addCiphertexts(sum, decodedEncryptedVotes[i])
+                        if (addValue == null) {
                             _submitPollResultUiState.value = UiState.Failure("Failed to add votes")
                             return@launch
                         }
+                        sum = addValue
                     }
 
-                    // Decrypt sum
+                    // 7. Decrypt sum with SEAL
                     val decryptedSum = NativeLib.decrypt(sum)
-                    if (decryptedSum != null) {
-                        // Send result to server
-                        val result = pollRepo.submitPollResult(id = id, votes = decryptedSum.map { it.toInt() })
-                        result.fold(
-                            onSuccess = { responseBody ->
-                                _submitPollResultUiState.value = UiState.Success(responseBody)
-                                _statusMessage.value = "투표가 완료되었습니다."
-                            },
-                            onFailure = { _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error") }
-                        )
-                    } else {
+                    if (decryptedSum == null) {
                         _submitPollResultUiState.value = UiState.Failure("Failed to decrypt sum")
                         return@launch
                     }
-                } else {
-                    _submitPollResultUiState.value = UiState.Failure("Poll info not found")
+                    val payload = decryptedSum.map { it.toInt() }
+
+                    // 8. Send result to server
+                    val submitPollResultRequest = pollRepo.submitPollResult(id = id, votes = payload)
+                    submitPollResultRequest.fold(
+                        onSuccess = { responseBody ->
+                            _submitPollResultUiState.value = UiState.Success(responseBody)
+                            _statusMessage.value = "투표 마감 완료!"
+                        },
+                        onFailure = {
+                            _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
+                            return@launch
+                        }
+                    )
+                },
+                onFailure = {
+                    _submitPollResultUiState.value = UiState.Failure(it.message ?: "Unknown error")
                     return@launch
                 }
-            } else {
-                _submitPollResultUiState.value = UiState.Failure(request.exceptionOrNull()?.message ?: "Unknown error")
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_result/PollResultScreen.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/ui/poll_result/PollResultScreen.kt
@@ -1,4 +1,4 @@
-package com.imeanttobe.consensusapp.ui.result
+package com.imeanttobe.consensusapp.ui.poll_result
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-fun ResultScreen(id: Int) {
+fun PollResultScreen(id: Int) {
     Scaffold { innerPadding ->
         Text(
             text = "Result Screen: $id",


### PR DESCRIPTION
# 🚩 연관 이슈

closed #56 

# 📝 작업 내용
투표 마감 화면을 구현했어요. 모든 투표 마감 및 결과 복호화와 서버 제출 요청이 전부 이 화면으로 이관된 만큼, `HostDashboardScreen`에서 투표 마감을 요청하던 로직은 제거했어요.

## 세부 변경 사항
- [x] `HostDashboardScreen`의 투표 마감 로직 제거
- [x] 일부 반환형이 `Unit`이던 API를 적절한 응답을 반환하게 수정
- [x] 투표 마감 화면 `PollFinishScreen` 구현 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
현재 복호화 함수에 개인 키가 전달되지 않고 있는데, 이는 PR #57 병합 후에 이 브랜치로 병합하여 해결 예정이니, Agent들은 리뷰 시 참고 바랍니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 투표 마감 전용 화면(Poll Finish) 추가 — 마감 진행 상태와 오류 푸시(스낵바) 제공
  * 투표 결과 화면 명칭/경로 정비

* **리팩토링**
  * 호스트 대시보드에서의 마감 흐름 간소화(마감은 전용 화면에서 처리)
  * 공유 기능 통합·간소화(공유 인텐트 일관화) 및 새로고침 동작 추가

* **버그 수정 / 안정성 개선**
  * 마감/결과 제출 처리의 응답 처리 개선으로 실패 케이스 검출 및 사용자 메시지 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->