### PR TITLE
[FEAT] FHE 곱셈 및 벤치마킹을 위한 함수 추가

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -41,7 +41,8 @@ add_subdirectory(SEAL)
 # .so (공유 라이브러리) 파일을 생성합니다.
 # (아직 jni_bridge.cpp 파일이 없으므로, 지금 바로 다음 단계에서 생성해야 합니다.)
 add_library(consensus_native SHARED
-        JNIBridge.cpp)
+        JNIBridge.cpp
+        JNIBenchmark.cpp)
 
 if(ANDROID)
     # NDK의 로깅 라이브러리를 찾습니다. (C++에서 Log.d(...) 사용 시 필요)

--- a/app/src/main/cpp/JNIBenchmark.cpp
+++ b/app/src/main/cpp/JNIBenchmark.cpp
@@ -1,0 +1,81 @@
+#include <jni.h>
+#include <chrono>
+#include <android/log.h>
+#include "seal/seal.h"
+#include "JNIBridge.h" // 공유할 g_context, g_evaluator 가져오기
+
+using namespace std;
+using namespace seal;
+
+// 벤치마크 전용 전역 데이터 (이 파일 내에서만 유지)
+static Ciphertext g_bench_ct1;
+static Ciphertext g_bench_ct2;
+static RelinKeys  g_bench_relin_keys;
+static bool       g_bench_ready = false;
+
+// 1. 사전 데이터 로드 (실험 시작 전 1회만 호출)
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_loadBenchmarkData(
+        JNIEnv *env,
+        jobject,
+        jbyteArray ct1Bytes,
+        jbyteArray ct2Bytes,
+        jbyteArray rkBytes) {
+    if (!g_context || !g_evaluator) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Context not initialized.");
+        return JNI_FALSE;
+    }
+
+    auto deserialize = [&](jbyteArray bytes, auto& obj) {
+        jsize len = env->GetArrayLength(bytes);
+        jbyte* ptr = env->GetByteArrayElements(bytes, nullptr);
+        string data(reinterpret_cast<char*>(ptr), len);
+        env->ReleaseByteArrayElements(bytes, ptr, JNI_ABORT); // 메모리 해제
+        stringstream stream(data);
+        obj.load(*g_context, stream);
+    };
+
+    try {
+        deserialize(ct1Bytes, g_bench_ct1);
+        deserialize(ct2Bytes, g_bench_ct2);
+        deserialize(rkBytes, g_bench_relin_keys);
+        g_bench_ready = true;
+        __android_log_print(ANDROID_LOG_INFO, "SEAL_BENCH", "Benchmark data loaded successfully.");
+        return JNI_TRUE;
+    } catch (...) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Failed to load benchmark data.");
+        return JNI_FALSE;
+    }
+}
+
+// 2. 순수 연산 벤치마크 실행 (반복 횟수를 받아 총 소요 시간을 ms 단위로 반환)
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_runBenchmarkMultiply(
+        JNIEnv *env,
+        jobject,
+        jint iterations) {
+    if (!g_bench_ready || !g_context || !g_evaluator) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Benchmark data not ready.");
+        return -1;
+    }
+
+    Ciphertext result_ct; // 결과를 덮어쓸 임시 객체
+
+    // --- 시간 측정 시작 ---
+    auto start_time = chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < iterations; i++) {
+        // 곱셈 수행 (크기가 3으로 늘어남)
+        g_evaluator->multiply(g_bench_ct1, g_bench_ct2, result_ct);
+        // 재선형화 수행 (In-place 연산으로 불필요한 메모리 복사 최소화, 크기 2로 복구)
+        g_evaluator->relinearize_inplace(result_ct, g_bench_relin_keys);
+    }
+
+    // --- 시간 측정 종료 ---
+    auto end_time = chrono::high_resolution_clock::now();
+
+    // 밀리초(ms) 단위로 변환
+    auto duration_ms = chrono::duration_cast<chrono::milliseconds>(end_time - start_time).count();
+
+    return static_cast<jlong>(duration_ms);
+}

--- a/app/src/main/cpp/JNIBenchmark.cpp
+++ b/app/src/main/cpp/JNIBenchmark.cpp
@@ -31,18 +31,20 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_loadBenchmarkData(
         return JNI_FALSE;
     }
 
-    auto deserialize = [&](jbyteArray bytes, auto& obj) {
+    auto deserialize = [&](jbyteArray bytes, auto& obj) -> bool {
         jsize len = env->GetArrayLength(bytes);
         jbyte* ptr = env->GetByteArrayElements(bytes, nullptr);
         if (!ptr) {
             __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Failed to get Java byte array elements.");
-            return;
+            return false;
         }
 
         string data(reinterpret_cast<char*>(ptr), len);
         env->ReleaseByteArrayElements(bytes, ptr, JNI_ABORT); // 메모리 해제
         stringstream stream(data);
         obj.load(*g_context, stream);
+
+        return true;
     };
 
     try {

--- a/app/src/main/cpp/JNIBenchmark.cpp
+++ b/app/src/main/cpp/JNIBenchmark.cpp
@@ -26,9 +26,19 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_loadBenchmarkData(
         return JNI_FALSE;
     }
 
+    if (!ct1Bytes || !ct2Bytes || !rkBytes) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Invalid input byte array.");
+        return JNI_FALSE;
+    }
+
     auto deserialize = [&](jbyteArray bytes, auto& obj) {
         jsize len = env->GetArrayLength(bytes);
         jbyte* ptr = env->GetByteArrayElements(bytes, nullptr);
+        if (!ptr) {
+            __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Failed to get Java byte array elements.");
+            return;
+        }
+
         string data(reinterpret_cast<char*>(ptr), len);
         env->ReleaseByteArrayElements(bytes, ptr, JNI_ABORT); // 메모리 해제
         stringstream stream(data);
@@ -42,6 +52,9 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_loadBenchmarkData(
         g_bench_ready = true;
         __android_log_print(ANDROID_LOG_INFO, "SEAL_BENCH", "Benchmark data loaded successfully.");
         return JNI_TRUE;
+    } catch (const exception& e) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Error in loadBenchmarkData: %s", e.what());
+        return JNI_FALSE;
     } catch (...) {
         __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Failed to load benchmark data.");
         return JNI_FALSE;
@@ -54,8 +67,15 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_runBenchmarkMultiply(
         JNIEnv *env,
         jobject,
         jint iterations) {
+    // Null check for params
     if (!g_bench_ready || !g_context || !g_evaluator) {
         __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Benchmark data not ready.");
+        return -1;
+    }
+
+    // Set upper bound and lower bound for iterations
+    if (iterations <= 0 || iterations > 1000000) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL_BENCH", "Invalid iteration count.");
         return -1;
     }
 

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -1,3 +1,6 @@
+#ifndef JNIBRIDGE_H
+#define JNIBRIDGE_H
+
 // Headers
 #include <jni.h>
 #include <string>
@@ -8,19 +11,18 @@
 #include "seal/seal.h"
 #include "JNIBridge.h"
 
-// Prefix: Java_com_imeanttobe_consensusapp_seal_NativeLib_
-
 // Namespaces
 using namespace std;
 using namespace seal;
 
 // Unique pointers
-static unique_ptr<SEALContext>  g_context;
-static unique_ptr<Evaluator>    g_evaluator;
-static unique_ptr<BatchEncoder> g_encoder;
+unique_ptr<SEALContext>  g_context;
+unique_ptr<Evaluator>    g_evaluator;
+unique_ptr<BatchEncoder> g_encoder;
 
 // Constants
 static const string PATH_SEAL_KEYS_CLASS = "com/imeanttobe/consensusapp/seal/SealKeys";
+static const int POLY_MODULUS_DEGREE = 8096;
 
 // JNI Functions
 // - Sample function
@@ -42,7 +44,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_initContext(JNIEnv *env, jobject
 
         // Set params for BFV scheme
         EncryptionParameters params(scheme_type::bfv);
-        size_t poly_modulus_degree = 4096;
+        size_t poly_modulus_degree = POLY_MODULUS_DEGREE;
         params.set_poly_modulus_degree(poly_modulus_degree);
         params.set_coeff_modulus(CoeffModulus::BFVDefault(poly_modulus_degree));
         params.set_plain_modulus(PlainModulus::Batching(poly_modulus_degree, 20));
@@ -78,10 +80,12 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
         // Generate key generator
         KeyGenerator keygen(*g_context);
 
-        // Create SK, PK
+        // Create SK, PK, RK
         SecretKey secret_key = keygen.secret_key();
         PublicKey public_key;
+        RelinKeys relin_key;
         keygen.create_public_key(public_key);
+        keygen.create_relin_keys(relin_key);
 
         // Serialize pk
         stringstream pk_stream;
@@ -101,6 +105,15 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
         jbyteArray sk_bytes = env->NewByteArray(static_cast<jsize>(serialized_sk.size()));
         env->SetByteArrayRegion(sk_bytes, 0, static_cast<jsize>(serialized_sk.size()), reinterpret_cast<const jbyte*>(serialized_sk.c_str()));
 
+        // Serialize rk
+        stringstream rk_stream;
+        relin_key.save(rk_stream);
+        string serialized_rk = rk_stream.str();
+
+        // Convert rk to jbyteArray
+        jbyteArray rk_bytes = env->NewByteArray(static_cast<jsize>(serialized_rk.size()));
+        env->SetByteArrayRegion(rk_bytes, 0, static_cast<jsize>(serialized_rk.size()), reinterpret_cast<const jbyte*>(serialized_rk.c_str()));
+
         // Find SealKeys class
         jclass seal_keys_class = env->FindClass(PATH_SEAL_KEYS_CLASS.c_str());
         if (seal_keys_class == nullptr) {
@@ -109,14 +122,14 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_generateKeys(JNIEnv *env, jobjec
         }
 
         // Find constructor
-        jmethodID constructor = env->GetMethodID(seal_keys_class, "<init>", "([B[B)V");
+        jmethodID constructor = env->GetMethodID(seal_keys_class, "<init>", "([B[B[B)V");
         if (constructor == nullptr) {
             __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Failed to find constructor.");
             return nullptr;
         }
 
         // Create Java object
-        jobject seal_keys = env->NewObject(seal_keys_class, constructor, pk_bytes, sk_bytes);
+        jobject seal_keys = env->NewObject(seal_keys_class, constructor, pk_bytes, sk_bytes, rk_bytes);
 
         return seal_keys;
     } catch (const exception &e) {
@@ -338,3 +351,87 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(
         return nullptr;
     }
 }
+
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_multiplyCiphertexts(
+        JNIEnv* env,
+        jobject,
+        jbyteArray cipherBytes1,
+        jbyteArray cipherBytes2,
+        jbyteArray relinKeyBytes) {
+    // Check whether context is initialized
+    if (!g_context || !g_evaluator) {
+        return nullptr;
+    }
+
+    // Check whether input byte arrays are valid
+    if (cipherBytes1 == nullptr || cipherBytes2 == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input ciphertext byte arrays are null.");
+        return nullptr;
+    }
+    if (relinKeyBytes == nullptr) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Input relin key byte array is null.");
+        return nullptr;
+    }
+
+    auto deserialize_ciphertext = [&](jbyteArray cipherBytes, Ciphertext& ct) {
+        // JNI ByteArray -> Ciphertext 역직렬화
+        jsize len = env->GetArrayLength(cipherBytes);
+        jbyte* ptr = env->GetByteArrayElements(cipherBytes, nullptr);
+        string serialized_data(reinterpret_cast<char*>(ptr), len);
+        env->ReleaseByteArrayElements(cipherBytes, ptr, JNI_ABORT);
+
+        // 결과 Ciphertext에 로드
+        stringstream stream(serialized_data);
+        ct.load(*g_context, stream);
+    };
+
+    auto deserialize_relin_key = [&](jbyteArray relinKeyBytes, RelinKeys& rk) {
+        // JNI ByteArray -> Ciphertext 역직렬화
+        jsize len = env->GetArrayLength(relinKeyBytes);
+        jbyte* ptr = env->GetByteArrayElements(relinKeyBytes, nullptr);
+        string serialized_data(reinterpret_cast<char*>(ptr), len);
+        env->ReleaseByteArrayElements(relinKeyBytes, ptr, JNI_ABORT);
+
+        // 결과 Ciphertext에 로드
+        stringstream stream(serialized_data);
+        rk.load(*g_context, stream);
+    };
+
+    try {
+        // --- 1. JNI ByteArray -> Ciphertext 역직렬화
+        Ciphertext encrypted1;
+        deserialize_ciphertext(cipherBytes1, encrypted1);
+
+        Ciphertext encrypted2;
+        deserialize_ciphertext(cipherBytes2, encrypted2);
+
+        RelinKeys relin_key;
+        deserialize_relin_key(relinKeyBytes, relin_key);
+
+        // --- 2. 곱셈 연산 (Ciphertext * Ciphertext) ---
+        Ciphertext encrypted_result;
+        g_evaluator->multiply(encrypted1, encrypted2, encrypted_result);
+        g_evaluator->relinearize_inplace(encrypted_result, relin_key);
+
+        // --- 3. 직렬화 (Ciphertext -> Byte Array) ---
+        stringstream result_stream;
+        encrypted_result.save(result_stream);
+        string serialized_result = result_stream.str();
+
+        jsize output_len = static_cast<jsize>(serialized_result.size());
+        jbyteArray result = env->NewByteArray(output_len);
+        env->SetByteArrayRegion(result, 0, output_len, reinterpret_cast<const jbyte*>(serialized_result.c_str()));
+
+        return result;
+    } catch (const exception& e) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Error in multiplyCiphertexts: %s", e.what());
+        return nullptr;
+    } catch (...) {
+        __android_log_print(ANDROID_LOG_ERROR, "SEAL", "Unknown error in multiplyCiphertexts");
+        return nullptr;
+    }
+}
+
+#endif

--- a/app/src/main/cpp/JNIBridge.cpp
+++ b/app/src/main/cpp/JNIBridge.cpp
@@ -1,14 +1,9 @@
-#ifndef JNIBRIDGE_H
-#define JNIBRIDGE_H
-
 // Headers
 #include <jni.h>
 #include <string>
 #include <vector>
 #include <sstream>
 #include <android/log.h>
-
-#include "seal/seal.h"
 #include "JNIBridge.h"
 
 // Namespaces
@@ -22,7 +17,7 @@ unique_ptr<BatchEncoder> g_encoder;
 
 // Constants
 static const string PATH_SEAL_KEYS_CLASS = "com/imeanttobe/consensusapp/seal/SealKeys";
-static const int POLY_MODULUS_DEGREE = 8096;
+static const int POLY_MODULUS_DEGREE = 8192;
 
 // JNI Functions
 // - Sample function
@@ -375,40 +370,28 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_multiplyCiphertexts(
         return nullptr;
     }
 
-    auto deserialize_ciphertext = [&](jbyteArray cipherBytes, Ciphertext& ct) {
-        // JNI ByteArray -> Ciphertext 역직렬화
-        jsize len = env->GetArrayLength(cipherBytes);
-        jbyte* ptr = env->GetByteArrayElements(cipherBytes, nullptr);
+    auto deserialize = [&](jbyteArray bytes, auto& obj) {
+        // JNI ByteArray -> SEAL object 역직렬화
+        jsize len = env->GetArrayLength(bytes);
+        jbyte* ptr = env->GetByteArrayElements(bytes, nullptr);
         string serialized_data(reinterpret_cast<char*>(ptr), len);
-        env->ReleaseByteArrayElements(cipherBytes, ptr, JNI_ABORT);
+        env->ReleaseByteArrayElements(bytes, ptr, JNI_ABORT);
 
-        // 결과 Ciphertext에 로드
+        // 결과 객체에 로드
         stringstream stream(serialized_data);
-        ct.load(*g_context, stream);
-    };
-
-    auto deserialize_relin_key = [&](jbyteArray relinKeyBytes, RelinKeys& rk) {
-        // JNI ByteArray -> Ciphertext 역직렬화
-        jsize len = env->GetArrayLength(relinKeyBytes);
-        jbyte* ptr = env->GetByteArrayElements(relinKeyBytes, nullptr);
-        string serialized_data(reinterpret_cast<char*>(ptr), len);
-        env->ReleaseByteArrayElements(relinKeyBytes, ptr, JNI_ABORT);
-
-        // 결과 Ciphertext에 로드
-        stringstream stream(serialized_data);
-        rk.load(*g_context, stream);
+        obj.load(*g_context, stream);
     };
 
     try {
         // --- 1. JNI ByteArray -> Ciphertext 역직렬화
         Ciphertext encrypted1;
-        deserialize_ciphertext(cipherBytes1, encrypted1);
+        deserialize(cipherBytes1, encrypted1);
 
         Ciphertext encrypted2;
-        deserialize_ciphertext(cipherBytes2, encrypted2);
+        deserialize(cipherBytes2, encrypted2);
 
         RelinKeys relin_key;
-        deserialize_relin_key(relinKeyBytes, relin_key);
+        deserialize(relinKeyBytes, relin_key);
 
         // --- 2. 곱셈 연산 (Ciphertext * Ciphertext) ---
         Ciphertext encrypted_result;
@@ -433,5 +416,3 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_multiplyCiphertexts(
         return nullptr;
     }
 }
-
-#endif

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -3,6 +3,10 @@
 
 // Prefix: Java_com_imeanttobe_consensusapp_seal_NativeLib_
 
+extern std::unique_ptr<seal::SEALContext> g_context;
+extern std::unique_ptr<seal::Evaluator> g_evaluator;
+extern std::unique_ptr<seal::BatchEncoder> g_encoder;
+
 // Test function
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_stringFromJNI(JNIEnv *env, jobject);
@@ -26,3 +30,7 @@ Java_com_imeanttobe_consensusapp_seal_NativeLib_decrypt(JNIEnv *env, jobject, jb
 // Adds two ciphertexts.
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_com_imeanttobe_consensusapp_seal_NativeLib_addCiphertexts(JNIEnv* env, jobject, jbyteArray cipherBytes1, jbyteArray cipherBytes2);
+
+// Multiply two ciphertexts.
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_imeanttobe_consensusapp_seal_NativeLib_multiplyCiphertexts(JNIEnv* env, jobject, jbyteArray cipherBytes1, jbyteArray cipherBytes2, jbyteArray relinKeyBytes);

--- a/app/src/main/cpp/JNIBridge.h
+++ b/app/src/main/cpp/JNIBridge.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <jni.h>
+#include <memory>
+#include "seal/seal.h"
 
 // Prefix: Java_com_imeanttobe_consensusapp_seal_NativeLib_
 

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -76,7 +76,7 @@ object NativeLib {
 
     /**
      * 순수 곱셈 연산 벤치마크 함수
-     * @params iterations 반복 횟수
+     * @param iterations 반복 횟수
      * @return 곱셈 연산에 걸린 시간 (long)
      */
     external fun runBenchmarkMultiply(iterations: Int): Long

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/NativeLib.kt
@@ -46,4 +46,38 @@ object NativeLib {
      * @return 합산된 암호문 (ByteArray?)
      */
     external fun addCiphertexts(cipherBytes1: ByteArray, cipherBytes2: ByteArray): ByteArray?
+
+    /**
+     * 두 개의 암호문을 동형암호 곱셈합니다.
+     * @param cipherBytes1 첫 번째 암호문
+     * @param cipherBytes2 두 번째 암호문
+     * @param relinKeyBytes 재선형화 키
+     * @return 곱셈된 암호문 (ByteArray?)
+     */
+    external fun multiplyCiphertexts(
+        cipherBytes1: ByteArray,
+        cipherBytes2: ByteArray,
+        relinKeyBytes: ByteArray
+    ): ByteArray?
+
+    // 벤치마킹 함수
+    /**
+     * 사전 데이터 로딩 함수 (사전 생성 암호문과 재선형화에 쓸 키)
+     * @param ct1Bytes 사전 데이터 암호문 1
+     * @param ct2Bytes 사전 데이터 암호문 2
+     * @param rkBytes 재선형화에 쓸 키
+     * @return 성공 여부 (Boolean)
+     */
+    external fun loadBenchmarkData(
+        ct1Bytes: ByteArray,
+        ct2Bytes: ByteArray,
+        rkBytes: ByteArray
+    ): Boolean
+
+    /**
+     * 순수 곱셈 연산 벤치마크 함수
+     * @params iterations 반복 횟수
+     * @return 곱셈 연산에 걸린 시간 (long)
+     */
+    external fun runBenchmarkMultiply(iterations: Int): Long
 }

--- a/app/src/main/java/com/imeanttobe/consensusapp/seal/SealKeys.kt
+++ b/app/src/main/java/com/imeanttobe/consensusapp/seal/SealKeys.kt
@@ -2,7 +2,8 @@ package com.imeanttobe.consensusapp.seal
 
 data class SealKeys(
     val pk: ByteArray,
-    val sk: ByteArray
+    val sk: ByteArray,
+    val rk: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -10,12 +11,14 @@ data class SealKeys(
         other as SealKeys
         if (!pk.contentEquals(other.pk)) return false
         if (!sk.contentEquals(other.sk)) return false
+        if (!rk.contentEquals(other.rk)) return false
         return true
     }
 
     override fun hashCode(): Int {
         var result = pk.contentHashCode()
         result = 31 * result + sk.contentHashCode()
+        result = 31 * result + rk.contentHashCode()
         return result
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,33 +1,33 @@
 [versions]
 # Default
-agp = "8.13.1"
-kotlin = "2.2.21"
+agp = "8.13.2"
+kotlin = "2.3.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.1"
-composeBom = "2025.12.00"
-material3 = "1.5.0-alpha10"
+activityCompose = "1.12.4"
+composeBom = "2026.02.00"
+material3 = "1.5.0-alpha15"
 
 # Hilt
-ksp = "2.2.21-2.0.4"
-navigation = "2.9.6"
-hilt = "2.57.2"
+hilt = "2.58"
+ksp = "2.3.2"
+navigation = "2.9.7"
 androidxHilt = "1.3.0"
 
 # Proto Datastore
-protobufKotlin = "4.33.1"
-protobuf = "0.9.5"
+protobufKotlin = "4.34.0"
+protobuf = "0.9.6"
 datastore = "1.2.0"
 
 # Network
 retrofit2 = "3.0.0"
 
 # Global
-serialization = "1.9.0"
-mockk = "1.14.6"
+serialization = "1.10.0"
+mockk = "1.14.9"
 icon = "1.7.8"
 immutableCollections = "0.4.0"
 


### PR DESCRIPTION
# 🚩 연관 이슈

closed #66

# 📝 작업 내용
- FHE 곱셈 함수 추가
- FHE 곱셈의 연산 성능 측정을 위한 벤치마킹 함수 추가
- 패키지 버전 업데이트

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 암호화된 데이터 곱셈 기능 추가(리러니어라이제이션 지원 포함)
  * 곱셈 성능 벤치마크: 벤치데이터 사전 로드 및 반복 실행 인터페이스 추가
  * 네이티브 API 확장: 곱셈 및 벤치마크 관련 새로운 외부 함수 제공

* **Chores**
  * 빌드 도구 및 라이브러리 버전 업데이트(AGP, Kotlin, Compose 등)

* **Style/Docs**
  * 키/직렬화 데이터 모델에 리린키 필드 추가 및 동등성/해시 로직 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->